### PR TITLE
Renamed time to t in message records

### DIFF
--- a/CogniPilot/Vehicles/RDD2/Components/Controller.mo
+++ b/CogniPilot/Vehicles/RDD2/Components/Controller.mo
@@ -24,7 +24,7 @@ algorithm
 
   when edge(
     sub_odometry.updated) then
-    pub_actuators.msg.time := time;
+    pub_actuators.msg.t := time;
 
     pub_actuators.msg.vel := {1+omega0,1+omega0,-1+omega0,-1+omega0};
 

--- a/CogniPilot/Vehicles/RDD2/Components/Dynamics.mo
+++ b/CogniPilot/Vehicles/RDD2/Components/Dynamics.mo
@@ -145,7 +145,7 @@ equation
 initial algorithm
   prop_w_cmd := sub_actuators.msg.vel;
 
-  pub_odometry.msg.time := time;
+  pub_odometry.msg.t := time;
 
   pub_odometry.msg.r_op_i := r_op_i;
 
@@ -162,7 +162,7 @@ algorithm
     prop_w_cmd := sub_actuators.msg.vel;
 
     // publish ground truth
-    pub_odometry.msg.time := time;
+    pub_odometry.msg.t := time;
 
     pub_odometry.msg.r_op_i := r_op_i;
 

--- a/CogniPilot/Vehicles/RDD2/Components/Estimator.mo
+++ b/CogniPilot/Vehicles/RDD2/Components/Estimator.mo
@@ -20,7 +20,7 @@ algorithm
     sub_imu.updated) then
     x := time;
 
-    pub_odometry.msg.time := time;
+    pub_odometry.msg.t := time;
 
     pub_odometry.msg.r_op_i := {time,time,time};
 

--- a/CogniPilot/Vehicles/RDD2/Components/IMU.mo
+++ b/CogniPilot/Vehicles/RDD2/Components/IMU.mo
@@ -18,7 +18,7 @@ equation
 algorithm
   when edge(
     pub_imu.updated) then
-    pub_imu.msg.time := time;
+    pub_imu.msg.t := time;
 
     pub_imu.msg.a_ip_b := frame.a_ip_b;
 

--- a/CogniPilot/ZROS/MsgActuators.mo
+++ b/CogniPilot/ZROS/MsgActuators.mo
@@ -1,6 +1,6 @@
 within CogniPilot.ZROS;
 record MsgActuators
-  Real time;
+  Real t;
 
   Real vel[4]
     "velocity command in [rad/s]";

--- a/CogniPilot/ZROS/MsgGyro.mo
+++ b/CogniPilot/ZROS/MsgGyro.mo
@@ -1,6 +1,6 @@
 within CogniPilot.ZROS;
 record MsgGyro
-  Real time;
+  Real t;
 
   Real omega_ib_b[3]
     "inertial angular acceleration expressed body frame [rad/s]";

--- a/CogniPilot/ZROS/MsgImu.mo
+++ b/CogniPilot/ZROS/MsgImu.mo
@@ -1,6 +1,6 @@
 within CogniPilot.ZROS;
 record MsgImu
-  Real time;
+  Real t;
 
   Real a_ip_b[3]
     "inertial acceleration expressed body frame [m/s^2]";

--- a/CogniPilot/ZROS/MsgOdometry.mo
+++ b/CogniPilot/ZROS/MsgOdometry.mo
@@ -1,6 +1,6 @@
 within CogniPilot.ZROS;
 record MsgOdometry
-  Real time;
+  Real t;
 
   Real r_op_i[3]
     "position expressed in inertial frame [m]";


### PR DESCRIPTION
Overloading time as a variable name appears to create conflicts during flattening.