### PR TITLE
Add LieGroups library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           stage="${RUNNER_TEMP}/${package_dir}"
 
           mkdir -p "${stage}"
-          cp -R Geodesy LieGroup RigidBody README.md LICENSE "${stage}/"
+          cp -R Geodesy LieGroup LieGroups RigidBody README.md LICENSE "${stage}/"
 
           (
             cd "${RUNNER_TEMP}"
@@ -72,6 +72,7 @@ jobs:
           This release contains the Modelica packages:
           - Geodesy
           - LieGroup
+          - LieGroups
           - RigidBody
           EOF
 

--- a/LieGroups/SE2/adjoint.mo
+++ b/LieGroups/SE2/adjoint.mo
@@ -1,0 +1,14 @@
+within LieGroups.SE2;
+function adjoint "Adjoint Ad_X for SE(2), translation-first ordering"
+  input Real X[3] "{px, py, theta}";
+  output Real Ad[3,3] "3x3 adjoint matrix";
+protected
+  Real c, s;
+algorithm
+  c := cos(X[3]);
+  s := sin(X[3]);
+  // Ad_X = {{R(theta), [py, -px]^T}, {0, 0, 1}}
+  Ad[1,1] := c;   Ad[1,2] := -s;  Ad[1,3] := X[2];
+  Ad[2,1] := s;   Ad[2,2] := c;   Ad[2,3] := -X[1];
+  Ad[3,1] := 0;   Ad[3,2] := 0;   Ad[3,3] := 1;
+end adjoint;

--- a/LieGroups/SE2/exp_map.mo
+++ b/LieGroups/SE2/exp_map.mo
@@ -1,0 +1,26 @@
+within LieGroups.SE2;
+function exp_map "Exponential map: se(2) -> SE(2)"
+  input Real xi[3] "Lie algebra {vx, vy, omega}";
+  output Real X[3] "Group element {px, py, theta}";
+protected
+  Real omega;
+  Real a "sin(omega)/omega";
+  Real b "(1-cos(omega))/omega";
+  constant Real eps = 1e-8;
+algorithm
+  omega := xi[3];
+
+  if abs(omega) < eps then
+    // Taylor series near omega=0
+    a := 1.0 - omega^2 / 6.0;
+    b := omega / 2.0 - omega^3 / 24.0;
+  else
+    a := sin(omega) / omega;
+    b := (1.0 - cos(omega)) / omega;
+  end if;
+
+  // p = V(omega) * v, where V = {{a, -b}, {b, a}}
+  X[1] := a*xi[1] - b*xi[2];
+  X[2] := b*xi[1] + a*xi[2];
+  X[3] := omega;
+end exp_map;

--- a/LieGroups/SE2/inverse.mo
+++ b/LieGroups/SE2/inverse.mo
@@ -1,0 +1,14 @@
+within LieGroups.SE2;
+function inverse "SE(2) inverse: (t,R)^{-1} = (-R^T*t, -theta)"
+  input Real X[3] "{px, py, theta}";
+  output Real X_inv[3] "{px_inv, py_inv, theta_inv}";
+protected
+  Real c, s;
+algorithm
+  c := cos(X[3]);
+  s := sin(X[3]);
+  // p_inv = -R(-theta) * p = -R^T * p
+  X_inv[1] := -(c*X[1] + s*X[2]);
+  X_inv[2] := -(-s*X[1] + c*X[2]);
+  X_inv[3] := -X[3];
+end inverse;

--- a/LieGroups/SE2/log_map.mo
+++ b/LieGroups/SE2/log_map.mo
@@ -1,0 +1,27 @@
+within LieGroups.SE2;
+function log_map "Logarithmic map: SE(2) -> se(2)"
+  input Real X[3] "Group element {px, py, theta}";
+  output Real xi[3] "Lie algebra {vx, vy, omega}";
+protected
+  Real theta;
+  Real a "sin(theta)/theta";
+  Real b "(1-cos(theta))/theta";
+  Real det_V;
+  constant Real eps = 1e-8;
+algorithm
+  theta := X[3];
+
+  if abs(theta) < eps then
+    a := 1.0 - theta^2 / 6.0;
+    b := theta / 2.0 - theta^3 / 24.0;
+  else
+    a := sin(theta) / theta;
+    b := (1.0 - cos(theta)) / theta;
+  end if;
+
+  // V_inv = {{a, b}, {-b, a}} / (a^2 + b^2)
+  det_V := a^2 + b^2;
+  xi[1] := (a*X[1] + b*X[2]) / det_V;
+  xi[2] := (-b*X[1] + a*X[2]) / det_V;
+  xi[3] := theta;
+end log_map;

--- a/LieGroups/SE2/package.mo
+++ b/LieGroups/SE2/package.mo
@@ -1,0 +1,8 @@
+within LieGroups;
+package SE2 "Special Euclidean Group SE(2) — 2D rigid body motions"
+  annotation(Documentation(info="<html>
+    <p>Group element: X = {px, py, theta} (translation-first ordering).</p>
+    <p>Lie algebra element: xi = {vx, vy, omega} (translation-first ordering).</p>
+    <p>Matches cyecca and AAE 590 PS02-04 conventions.</p>
+  </html>"));
+end SE2;

--- a/LieGroups/SE2/product.mo
+++ b/LieGroups/SE2/product.mo
@@ -1,0 +1,16 @@
+within LieGroups.SE2;
+function product "SE(2) group product: (t1,R1) * (t2,R2) = (R1*t2+t1, R1*R2)"
+  input Real X1[3] "{px1, py1, theta1}";
+  input Real X2[3] "{px2, py2, theta2}";
+  output Real X[3] "{px, py, theta}";
+protected
+  Real c1, s1;
+algorithm
+  c1 := cos(X1[3]);
+  s1 := sin(X1[3]);
+  // p = R(theta1) * p2 + p1
+  X[1] := c1*X2[1] - s1*X2[2] + X1[1];
+  X[2] := s1*X2[1] + c1*X2[2] + X1[2];
+  // theta = theta1 + theta2
+  X[3] := X1[3] + X2[3];
+end product;

--- a/LieGroups/SE2/small_adjoint.mo
+++ b/LieGroups/SE2/small_adjoint.mo
@@ -1,0 +1,11 @@
+within LieGroups.SE2;
+function small_adjoint "Small adjoint ad_xi for se(2), translation-first ordering"
+  input Real xi[3] "Lie algebra {vx, vy, omega}";
+  output Real ad[3,3] "3x3 small adjoint matrix";
+algorithm
+  // ad_xi = {{omega^wedge, [vy, -vx]^T}, {0, 0, 0}}
+  // where omega^wedge (2D) = {{0, -omega}, {omega, 0}}
+  ad[1,1] := 0;        ad[1,2] := -xi[3];  ad[1,3] := xi[2];
+  ad[2,1] := xi[3];    ad[2,2] := 0;       ad[2,3] := -xi[1];
+  ad[3,1] := 0;        ad[3,2] := 0;       ad[3,3] := 0;
+end small_adjoint;

--- a/LieGroups/SE2/to_Matrix.mo
+++ b/LieGroups/SE2/to_Matrix.mo
@@ -1,0 +1,13 @@
+within LieGroups.SE2;
+function to_Matrix "Convert SE(2) element to 3x3 homogeneous matrix"
+  input Real X[3] "{px, py, theta}";
+  output Real M[3,3] "3x3 matrix {{R, p}, {0, 1}}";
+protected
+  Real c, s;
+algorithm
+  c := cos(X[3]);
+  s := sin(X[3]);
+  M[1,1] := c;   M[1,2] := -s;  M[1,3] := X[1];
+  M[2,1] := s;   M[2,2] := c;   M[2,3] := X[2];
+  M[3,1] := 0;   M[3,2] := 0;   M[3,3] := 1;
+end to_Matrix;

--- a/LieGroups/SE2/vee.mo
+++ b/LieGroups/SE2/vee.mo
@@ -1,0 +1,9 @@
+within LieGroups.SE2;
+function vee "Vee map: 3x3 se(2) matrix -> vector (M^vee)"
+  input Real M[3,3] "3x3 Lie algebra matrix";
+  output Real xi[3] "Lie algebra {vx, vy, omega}";
+algorithm
+  xi[1] := M[1,3];
+  xi[2] := M[2,3];
+  xi[3] := M[2,1];
+end vee;

--- a/LieGroups/SE2/wedge.mo
+++ b/LieGroups/SE2/wedge.mo
@@ -1,0 +1,9 @@
+within LieGroups.SE2;
+function wedge "Wedge map: se(2) vector -> 3x3 matrix (xi^wedge)"
+  input Real xi[3] "Lie algebra {vx, vy, omega}";
+  output Real M[3,3] "3x3 Lie algebra matrix";
+algorithm
+  M[1,1] := 0;       M[1,2] := -xi[3];  M[1,3] := xi[1];
+  M[2,1] := xi[3];   M[2,2] := 0;       M[2,3] := xi[2];
+  M[3,1] := 0;       M[3,2] := 0;       M[3,3] := 0;
+end wedge;

--- a/LieGroups/SE23/Quat/adjoint.mo
+++ b/LieGroups/SE23/Quat/adjoint.mo
@@ -1,0 +1,32 @@
+within LieGroups.SE23.Quat;
+function adjoint "Adjoint Ad_X for SE_2(3)"
+  input Real X[10] "{p, v, q}";
+  output Real Ad[9,9] "9x9 adjoint matrix";
+protected
+  Real R[3,3];
+  Real px[3,3] "Skew [p]x";
+  Real vx[3,3] "Skew [v]x";
+  Real pR[3,3] "[p]x * R";
+  Real vR[3,3] "[v]x * R";
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(X[7:10]);
+  px := LieGroups.SO3.Quat.wedge(X[1:3]);
+  vx := LieGroups.SO3.Quat.wedge(X[4:6]);
+
+  // [p]x * R and [v]x * R
+  for i in 1:3 loop
+    for j in 1:3 loop
+      pR[i,j] := px[i,1]*R[1,j] + px[i,2]*R[2,j] + px[i,3]*R[3,j];
+      vR[i,j] := vx[i,1]*R[1,j] + vx[i,2]*R[2,j] + vx[i,3]*R[3,j];
+    end for;
+  end for;
+
+  // Ad = {{R, 0, [p]x*R}, {0, R, [v]x*R}, {0, 0, R}}
+  for i in 1:3 loop
+    for j in 1:3 loop
+      Ad[i,j]     := R[i,j];    Ad[i,j+3]   := 0;        Ad[i,j+6]   := pR[i,j];
+      Ad[i+3,j]   := 0;         Ad[i+3,j+3] := R[i,j];   Ad[i+3,j+6] := vR[i,j];
+      Ad[i+6,j]   := 0;         Ad[i+6,j+3] := 0;         Ad[i+6,j+6] := R[i,j];
+    end for;
+  end for;
+end adjoint;

--- a/LieGroups/SE23/Quat/exp_map.mo
+++ b/LieGroups/SE23/Quat/exp_map.mo
@@ -1,0 +1,90 @@
+within LieGroups.SE23.Quat;
+function exp_map "Exponential map: se_2(3) -> SE_2(3) via 5x5 matrix series"
+  input Real xi[9] "Lie algebra {vb, ab, omega}";
+  output Real X[10] "Group element {p, v, q}";
+protected
+  Real omega[3];
+  Real theta_sq;
+  Real C1 "(1-cos theta)/theta^2";
+  Real C2 "(theta-sin theta)/theta^3";
+  Real theta;
+  constant Real eps = 1e-8;
+  // 5x5 matrix approach: build algebra matrix, compute I + M*(I + C1*M + C2*M^2)
+  Real M[5,5] "Lie algebra matrix";
+  Real M2[5,5] "M*M";
+  Real inner_mat[5,5] "I + C1*M + C2*M^2";
+  Real result[5,5] "I + M*inner_mat";
+  Real R_mat[3,3];
+  Real q[4];
+algorithm
+  omega := xi[7:9];
+  theta_sq := omega[1]^2 + omega[2]^2 + omega[3]^2;
+
+  if theta_sq < eps then
+    C1 := 0.5 - theta_sq / 24.0;
+    C2 := 1.0/6.0 - theta_sq / 120.0;
+  else
+    theta := sqrt(theta_sq);
+    C1 := (1.0 - cos(theta)) / theta_sq;
+    C2 := (theta - sin(theta)) / (theta_sq * theta);
+  end if;
+
+  // Build 5x5 algebra matrix:
+  // [omega^  a_b  v_b]
+  // [0       0    0  ]
+  // [0       0    0  ]
+  for i in 1:5 loop
+    for j in 1:5 loop
+      M[i,j] := 0;
+    end for;
+  end for;
+  // Rotation block (top-left 3x3)
+  M[1,2] := -omega[3]; M[1,3] := omega[2];
+  M[2,1] := omega[3];  M[2,3] := -omega[1];
+  M[3,1] := -omega[2]; M[3,2] := omega[1];
+  // Acceleration column (col 4)
+  M[1,4] := xi[4]; M[2,4] := xi[5]; M[3,4] := xi[6];
+  // Velocity column (col 5)
+  M[1,5] := xi[1]; M[2,5] := xi[2]; M[3,5] := xi[3];
+
+  // M^2
+  for i in 1:5 loop
+    for j in 1:5 loop
+      M2[i,j] := 0;
+      for k in 1:5 loop
+        M2[i,j] := M2[i,j] + M[i,k]*M[k,j];
+      end for;
+    end for;
+  end for;
+
+  // inner_mat = I + C1*M + C2*M^2
+  for i in 1:5 loop
+    for j in 1:5 loop
+      inner_mat[i,j] := (if i == j then 1.0 else 0.0) + C1*M[i,j] + C2*M2[i,j];
+    end for;
+  end for;
+
+  // result = I + M * inner_mat
+  for i in 1:5 loop
+    for j in 1:5 loop
+      result[i,j] := if i == j then 1.0 else 0.0;
+      for k in 1:5 loop
+        result[i,j] := result[i,j] + M[i,k]*inner_mat[k,j];
+      end for;
+    end for;
+  end for;
+
+  // Extract: position = col 5 (rows 1-3), velocity = col 4 (rows 1-3)
+  // rotation = top-left 3x3 -> quaternion
+  for i in 1:3 loop
+    for j in 1:3 loop
+      R_mat[i,j] := result[i,j];
+    end for;
+  end for;
+  q := LieGroups.SO3.Quat.from_DCM(R_mat);
+
+  // Note: cyecca from_Matrix swaps columns: p = col5, v = col4
+  X[1] := result[1,5]; X[2] := result[2,5]; X[3] := result[3,5];
+  X[4] := result[1,4]; X[5] := result[2,4]; X[6] := result[3,4];
+  X[7] := q[1]; X[8] := q[2]; X[9] := q[3]; X[10] := q[4];
+end exp_map;

--- a/LieGroups/SE23/Quat/exp_mixed.mo
+++ b/LieGroups/SE23/Quat/exp_mixed.mo
@@ -1,0 +1,191 @@
+within LieGroups.SE23.Quat;
+function exp_mixed "Mixed exponential for SE_2(3) INS propagation"
+  input Real X0[10] "Initial state {p0, v0, q0}";
+  input Real l[9] "Left (body-frame) algebra element {vb, ab, omega_l}";
+  input Real r[9] "Right (world-frame) algebra element {vb_r, ab_r, omega_r}";
+  input Real B[2,2] "Coupling matrix (typically {{0,1},{0,0}})";
+  output Real X1[10] "Updated state {p1, v1, q1}";
+protected
+  Real omega_l[3], omega_r[3];
+  Real theta_sq;
+  Real C1, C2, C3;
+  Real theta;
+  constant Real eps = 1e-8;
+
+  // Omega matrix and its square
+  Real Om[3,3], Om2[3,3];
+
+  // A matrices (3x2): [a_b | v_b] for left and right
+  Real Al[3,2], Ar[3,2];
+
+  // N matrices (3x2): calculated for left and right
+  Real Nl[3,2], Nr[3,2];
+
+  // Intermediate products
+  Real OmAl[3,2], Om2Al[3,2];
+  Real OmAr[3,2], Om2Ar[3,2];
+  Real AlB[3,2], ArBn[3,2];
+  Real I2[2,2];
+  Real IpB[2,2], ImB[2,2];
+
+  // Rotation quaternions
+  Real q_l[4], q_r[4], q_r0[4], q1[4];
+  Real R_r0[3,3], R_r[3,3];
+
+  // P matrices (3x2): [v | p]
+  Real P0[3,2], P1[3,2];
+  Real term1[3,2], term2[3,2], term3[3,2];
+algorithm
+  omega_l := l[7:9];
+  omega_r := r[7:9];
+
+  theta_sq := omega_l[1]^2 + omega_l[2]^2 + omega_l[3]^2;
+
+  if theta_sq < eps then
+    C1 := 0.5 - theta_sq / 24.0;
+    C2 := 1.0/6.0 - theta_sq / 120.0;
+    C3 := 1.0/24.0 - theta_sq / 720.0;
+  else
+    theta := sqrt(theta_sq);
+    C1 := (1.0 - cos(theta)) / theta_sq;
+    C2 := (theta - sin(theta)) / (theta_sq * theta);
+    // C3 = (theta^2/2 + cos(theta) - 1) / theta^4
+    C3 := (theta_sq/2.0 + cos(theta) - 1.0) / (theta_sq * theta_sq);
+  end if;
+
+  // Build Omega (skew of omega_l) and Omega^2
+  Om := LieGroups.SO3.Quat.wedge(omega_l);
+  for i in 1:3 loop
+    for j in 1:3 loop
+      Om2[i,j] := Om[i,1]*Om[1,j] + Om[i,2]*Om[2,j] + Om[i,3]*Om[3,j];
+    end for;
+  end for;
+
+  // A_l = [a_b | v_b] (columns: acceleration, velocity from left algebra)
+  Al := {{l[4], l[1]}, {l[5], l[2]}, {l[6], l[3]}};
+  Ar := {{r[4], r[1]}, {r[5], r[2]}, {r[6], r[3]}};
+
+  I2 := {{1, 0}, {0, 1}};
+
+  // Omega*A and Omega^2*A for left
+  for i in 1:3 loop
+    for k in 1:2 loop
+      OmAl[i,k] := Om[i,1]*Al[1,k] + Om[i,2]*Al[2,k] + Om[i,3]*Al[3,k];
+      Om2Al[i,k] := Om2[i,1]*Al[1,k] + Om2[i,2]*Al[2,k] + Om2[i,3]*Al[3,k];
+    end for;
+  end for;
+
+  // A*B for left
+  for i in 1:3 loop
+    for k in 1:2 loop
+      AlB[i,k] := Al[i,1]*B[1,k] + Al[i,2]*B[2,k];
+    end for;
+  end for;
+
+  // N_l = A + A*B/2 + Om*A*(C1*I + C2*B) + Om^2*A*(C2*I + C3*B)
+  for i in 1:3 loop
+    for k in 1:2 loop
+      Nl[i,k] := Al[i,k] + AlB[i,k]/2.0;
+      // Om*A*(C1*I + C2*B)
+      for j in 1:2 loop
+        Nl[i,k] := Nl[i,k] + OmAl[i,j]*(C1*(if j==k then 1.0 else 0.0) + C2*B[j,k]);
+      end for;
+      // Om^2*A*(C2*I + C3*B)
+      for j in 1:2 loop
+        Nl[i,k] := Nl[i,k] + Om2Al[i,j]*(C2*(if j==k then 1.0 else 0.0) + C3*B[j,k]);
+      end for;
+    end for;
+  end for;
+
+  // N_r: same formula but with r algebra and -B
+  // Recompute with omega_r for the rotation part (but cyecca uses omega_l for both N computations)
+  // Actually cyecca uses l's omega for Nl and r's omega for Nr - but r's omega is typically 0 or small
+  // For simplicity and matching cyecca: Nr uses the same series but with -B and r's A
+  // The Omega in Nr should use r's omega
+  // For the standard INS case, r has omega_r = 0, so Om_r = 0 and Nr = Ar + Ar*(-B)/2
+  // Let me implement the general case with r's omega:
+
+  // For Nr, we need omega_r's series coefficients
+  theta_sq := omega_r[1]^2 + omega_r[2]^2 + omega_r[3]^2;
+  if theta_sq < eps then
+    C1 := 0.5 - theta_sq / 24.0;
+    C2 := 1.0/6.0 - theta_sq / 120.0;
+    C3 := 1.0/24.0 - theta_sq / 720.0;
+  else
+    theta := sqrt(theta_sq);
+    C1 := (1.0 - cos(theta)) / theta_sq;
+    C2 := (theta - sin(theta)) / (theta_sq * theta);
+    C3 := (theta_sq/2.0 + cos(theta) - 1.0) / (theta_sq * theta_sq);
+  end if;
+
+  Om := LieGroups.SO3.Quat.wedge(omega_r);
+  for i in 1:3 loop
+    for j in 1:3 loop
+      Om2[i,j] := Om[i,1]*Om[1,j] + Om[i,2]*Om[2,j] + Om[i,3]*Om[3,j];
+    end for;
+  end for;
+
+  for i in 1:3 loop
+    for k in 1:2 loop
+      OmAr[i,k] := Om[i,1]*Ar[1,k] + Om[i,2]*Ar[2,k] + Om[i,3]*Ar[3,k];
+      Om2Ar[i,k] := Om2[i,1]*Ar[1,k] + Om2[i,2]*Ar[2,k] + Om2[i,3]*Ar[3,k];
+      ArBn[i,k] := -(Ar[i,1]*B[1,k] + Ar[i,2]*B[2,k]);
+    end for;
+  end for;
+
+  for i in 1:3 loop
+    for k in 1:2 loop
+      Nr[i,k] := Ar[i,k] + ArBn[i,k]/2.0;
+      for j in 1:2 loop
+        Nr[i,k] := Nr[i,k] + OmAr[i,j]*(C1*(if j==k then 1.0 else 0.0) - C2*B[j,k]);
+      end for;
+      for j in 1:2 loop
+        Nr[i,k] := Nr[i,k] + Om2Ar[i,j]*(C2*(if j==k then 1.0 else 0.0) - C3*B[j,k]);
+      end for;
+    end for;
+  end for;
+
+  // Rotation updates
+  q_l := LieGroups.SO3.Quat.exp_map(omega_l);
+  q_r := LieGroups.SO3.Quat.exp_map(omega_r);
+  q_r0 := LieGroups.SO3.Quat.product(q_r, X0[7:10]);
+  q1 := LieGroups.SO3.Quat.product(q_r0, q_l);
+
+  R_r0 := LieGroups.SO3.Quat.to_DCM(q_r0);
+  R_r := LieGroups.SO3.Quat.to_DCM(q_r);
+
+  // P0 = [v0 | p0]
+  P0 := {{X0[4], X0[1]}, {X0[5], X0[2]}, {X0[6], X0[3]}};
+
+  // I + B
+  IpB := {{1 + B[1,1], B[1,2]}, {B[2,1], 1 + B[2,2]}};
+
+  // P1 = R_r0 * Nl + (R_r * P0 + Nr) * (I + B)
+  // term1 = R_r0 * Nl
+  for i in 1:3 loop
+    for k in 1:2 loop
+      term1[i,k] := R_r0[i,1]*Nl[1,k] + R_r0[i,2]*Nl[2,k] + R_r0[i,3]*Nl[3,k];
+    end for;
+  end for;
+
+  // term2 = R_r * P0 + Nr
+  for i in 1:3 loop
+    for k in 1:2 loop
+      term2[i,k] := R_r[i,1]*P0[1,k] + R_r[i,2]*P0[2,k] + R_r[i,3]*P0[3,k] + Nr[i,k];
+    end for;
+  end for;
+
+  // term3 = term2 * (I + B)
+  for i in 1:3 loop
+    for k in 1:2 loop
+      term3[i,k] := term2[i,1]*IpB[1,k] + term2[i,2]*IpB[2,k];
+    end for;
+  end for;
+
+  P1 := {{term1[i,k] + term3[i,k] for k in 1:2} for i in 1:3};
+
+  // Extract: p = P1 col 2, v = P1 col 1 (cyecca swaps: vertcat(P1[:,1], P1[:,0], R1))
+  X1[1] := P1[1,2]; X1[2] := P1[2,2]; X1[3] := P1[3,2];
+  X1[4] := P1[1,1]; X1[5] := P1[2,1]; X1[6] := P1[3,1];
+  X1[7] := q1[1]; X1[8] := q1[2]; X1[9] := q1[3]; X1[10] := q1[4];
+end exp_mixed;

--- a/LieGroups/SE23/Quat/inverse.mo
+++ b/LieGroups/SE23/Quat/inverse.mo
@@ -1,0 +1,27 @@
+within LieGroups.SE23.Quat;
+function inverse "SE_2(3) inverse"
+  input Real X[10] "{p, v, q}";
+  output Real X_inv[10] "{p_inv, v_inv, q_inv}";
+protected
+  Real q_inv[4];
+  Real p_rot[3], v_rot[3];
+algorithm
+  q_inv := LieGroups.SO3.Quat.inverse(X[7:10]);
+
+  // p_inv = -R^{-1} * p
+  p_rot := LieGroups.SO3.Quat.rotate(q_inv, X[1:3]);
+  X_inv[1] := -p_rot[1];
+  X_inv[2] := -p_rot[2];
+  X_inv[3] := -p_rot[3];
+
+  // v_inv = -R^{-1} * v
+  v_rot := LieGroups.SO3.Quat.rotate(q_inv, X[4:6]);
+  X_inv[4] := -v_rot[1];
+  X_inv[5] := -v_rot[2];
+  X_inv[6] := -v_rot[3];
+
+  X_inv[7] := q_inv[1];
+  X_inv[8] := q_inv[2];
+  X_inv[9] := q_inv[3];
+  X_inv[10] := q_inv[4];
+end inverse;

--- a/LieGroups/SE23/Quat/left_jacobian.mo
+++ b/LieGroups/SE23/Quat/left_jacobian.mo
@@ -1,0 +1,35 @@
+within LieGroups.SE23.Quat;
+function left_jacobian "Forward left Jacobian J_l of SE_2(3) (9x9)"
+  input Real xi[9] "Lie algebra {vb, ab, omega}";
+  output Real J[9,9] "9x9 left Jacobian";
+protected
+  Real Jl[3,3] "SO(3) left Jacobian of omega";
+  Real Qv[3,3] "Q block for velocity-column part vb";
+  Real Qa[3,3] "Q block for acceleration-column part ab";
+  Real omega[3];
+algorithm
+  omega := xi[7:9];
+  Jl := LieGroups.SO3.Quat.left_jacobian(omega);
+  Qv := LieGroups.SE3.Quat.left_Q(xi[1:3], omega);
+  Qa := LieGroups.SE3.Quat.left_Q(xi[4:6], omega);
+
+  // Block structure (ordering {vb, ab, omega}):
+  // J = {{Jl, 0, Qv}, {0, Jl, Qa}, {0, 0, Jl}}
+  for i in 1:9 loop
+    for j in 1:9 loop
+      J[i,j] := 0.0;
+    end for;
+  end for;
+  for i in 1:3 loop
+    for j in 1:3 loop
+      J[i,j]     := Jl[i,j];   J[i,j+6]   := Qv[i,j];
+      J[i+3,j+3] := Jl[i,j];   J[i+3,j+6] := Qa[i,j];
+      J[i+6,j+6] := Jl[i,j];
+    end for;
+  end for;
+
+  annotation(Documentation(info="<html>
+    <p>Forward left Jacobian of SE_2(3), matching cyecca <code>se23.left_jacobian</code>.</p>
+    <p>Used by log-linear dynamic-inversion control: n = nbar - J_l(xi) BK xi.</p>
+  </html>"));
+end left_jacobian;

--- a/LieGroups/SE23/Quat/log_map.mo
+++ b/LieGroups/SE23/Quat/log_map.mo
@@ -1,0 +1,35 @@
+within LieGroups.SE23.Quat;
+function log_map "Logarithmic map: SE_2(3) -> se_2(3)"
+  input Real X[10] "Group element {p, v, q}";
+  output Real xi[9] "Lie algebra {vb, ab, omega}";
+protected
+  Real omega[3];
+  Real theta_sq;
+  Real J_inv[3,3];
+  constant Real eps = 1e-8;
+algorithm
+  // omega = log_SO3(q)
+  omega := LieGroups.SO3.Quat.log_map(X[7:10]);
+  xi[7] := omega[1];
+  xi[8] := omega[2];
+  xi[9] := omega[3];
+
+  theta_sq := omega[1]^2 + omega[2]^2 + omega[3]^2;
+
+  if theta_sq < eps then
+    // Near identity: V_inv ~ I
+    // vb = p, ab = v
+    xi[1] := X[1]; xi[2] := X[2]; xi[3] := X[3];
+    xi[4] := X[4]; xi[5] := X[5]; xi[6] := X[6];
+  else
+    J_inv := LieGroups.SO3.Quat.left_jacobian_inv(omega);
+    // vb = J_l^{-1} * p
+    xi[1] := J_inv[1,1]*X[1] + J_inv[1,2]*X[2] + J_inv[1,3]*X[3];
+    xi[2] := J_inv[2,1]*X[1] + J_inv[2,2]*X[2] + J_inv[2,3]*X[3];
+    xi[3] := J_inv[3,1]*X[1] + J_inv[3,2]*X[2] + J_inv[3,3]*X[3];
+    // ab = J_l^{-1} * v
+    xi[4] := J_inv[1,1]*X[4] + J_inv[1,2]*X[5] + J_inv[1,3]*X[6];
+    xi[5] := J_inv[2,1]*X[4] + J_inv[2,2]*X[5] + J_inv[2,3]*X[6];
+    xi[6] := J_inv[3,1]*X[4] + J_inv[3,2]*X[5] + J_inv[3,3]*X[6];
+  end if;
+end log_map;

--- a/LieGroups/SE23/Quat/package.mo
+++ b/LieGroups/SE23/Quat/package.mo
@@ -1,0 +1,8 @@
+within LieGroups.SE23;
+package Quat "SE_2(3) with quaternion rotation parameterization"
+  annotation(Documentation(info="<html>
+    <p>Group element: X = {px,py,pz, vx,vy,vz, qw,qx,qy,qz} (10 params).</p>
+    <p>Lie algebra: xi = {vb_x,vb_y,vb_z, ab_x,ab_y,ab_z, omega_x,omega_y,omega_z} (9 params).</p>
+    <p>Ordering: position, velocity, rotation (group); velocity, acceleration, rotation (algebra).</p>
+  </html>"));
+end Quat;

--- a/LieGroups/SE23/Quat/product.mo
+++ b/LieGroups/SE23/Quat/product.mo
@@ -1,0 +1,28 @@
+within LieGroups.SE23.Quat;
+function product "SE_2(3) group product"
+  input Real X1[10] "{p1, v1, q1}";
+  input Real X2[10] "{p2, v2, q2}";
+  output Real X[10] "{p, v, q}";
+protected
+  Real p_rot[3], v_rot[3];
+  Real q_prod[4];
+algorithm
+  // p = R(q1)*p2 + p1
+  p_rot := LieGroups.SO3.Quat.rotate(X1[7:10], X2[1:3]);
+  X[1] := p_rot[1] + X1[1];
+  X[2] := p_rot[2] + X1[2];
+  X[3] := p_rot[3] + X1[3];
+
+  // v = R(q1)*v2 + v1
+  v_rot := LieGroups.SO3.Quat.rotate(X1[7:10], X2[4:6]);
+  X[4] := v_rot[1] + X1[4];
+  X[5] := v_rot[2] + X1[5];
+  X[6] := v_rot[3] + X1[6];
+
+  // q = q1 * q2
+  q_prod := LieGroups.SO3.Quat.product(X1[7:10], X2[7:10]);
+  X[7] := q_prod[1];
+  X[8] := q_prod[2];
+  X[9] := q_prod[3];
+  X[10] := q_prod[4];
+end product;

--- a/LieGroups/SE23/Quat/small_adjoint.mo
+++ b/LieGroups/SE23/Quat/small_adjoint.mo
@@ -1,0 +1,22 @@
+within LieGroups.SE23.Quat;
+function small_adjoint "Small adjoint ad_xi for se_2(3)"
+  input Real xi[9] "Lie algebra {vb, ab, omega}";
+  output Real ad[9,9] "9x9 small adjoint matrix";
+protected
+  Real vx[3,3] "Skew [vb]x";
+  Real ax[3,3] "Skew [ab]x";
+  Real wx[3,3] "Skew [omega]x";
+algorithm
+  vx := LieGroups.SO3.Quat.wedge(xi[1:3]);
+  ax := LieGroups.SO3.Quat.wedge(xi[4:6]);
+  wx := LieGroups.SO3.Quat.wedge(xi[7:9]);
+
+  // ad = {{[omega]x, 0, [vb]x}, {0, [omega]x, [ab]x}, {0, 0, [omega]x}}
+  for i in 1:3 loop
+    for j in 1:3 loop
+      ad[i,j]     := wx[i,j];   ad[i,j+3]   := 0;        ad[i,j+6]   := vx[i,j];
+      ad[i+3,j]   := 0;         ad[i+3,j+3] := wx[i,j];  ad[i+3,j+6] := ax[i,j];
+      ad[i+6,j]   := 0;         ad[i+6,j+3] := 0;         ad[i+6,j+6] := wx[i,j];
+    end for;
+  end for;
+end small_adjoint;

--- a/LieGroups/SE23/Quat/to_Matrix.mo
+++ b/LieGroups/SE23/Quat/to_Matrix.mo
@@ -1,0 +1,18 @@
+within LieGroups.SE23.Quat;
+function to_Matrix "Convert SE_2(3) element to 5x5 matrix"
+  input Real X[10] "{p, v, q}";
+  output Real M[5,5] "5x5 matrix {{R, v, p}, {0, I_2}}";
+protected
+  Real R[3,3];
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(X[7:10]);
+  for i in 1:3 loop
+    for j in 1:3 loop
+      M[i,j] := R[i,j];
+    end for;
+    M[i,4] := X[i+3];  // velocity column
+    M[i,5] := X[i];    // position column
+  end for;
+  M[4,1] := 0; M[4,2] := 0; M[4,3] := 0; M[4,4] := 1; M[4,5] := 0;
+  M[5,1] := 0; M[5,2] := 0; M[5,3] := 0; M[5,4] := 0; M[5,5] := 1;
+end to_Matrix;

--- a/LieGroups/SE23/package.mo
+++ b/LieGroups/SE23/package.mo
@@ -1,0 +1,3 @@
+within LieGroups;
+package SE23 "Extended Pose Group SE_2(3) — position, velocity, and rotation"
+end SE23;

--- a/LieGroups/SE3/Quat/adjoint.mo
+++ b/LieGroups/SE3/Quat/adjoint.mo
@@ -1,0 +1,31 @@
+within LieGroups.SE3.Quat;
+function adjoint "Adjoint Ad_X for SE(3), translation-first ordering"
+  input Real X[7] "{px,py,pz, qw,qx,qy,qz}";
+  output Real Ad[6,6] "6x6 adjoint matrix";
+protected
+  Real R[3,3] "Rotation matrix";
+  Real px[3,3] "Skew [p]x";
+  Real pR[3,3] "[p]x * R";
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(X[4:7]);
+
+  // Skew of position
+  px := LieGroups.SO3.Quat.wedge(X[1:3]);
+
+  // [p]x * R
+  for i in 1:3 loop
+    for j in 1:3 loop
+      pR[i,j] := px[i,1]*R[1,j] + px[i,2]*R[2,j] + px[i,3]*R[3,j];
+    end for;
+  end for;
+
+  // Ad = {{R, [p]x*R}, {0, R}}
+  for i in 1:3 loop
+    for j in 1:3 loop
+      Ad[i,j] := R[i,j];
+      Ad[i,j+3] := pR[i,j];
+      Ad[i+3,j] := 0;
+      Ad[i+3,j+3] := R[i,j];
+    end for;
+  end for;
+end adjoint;

--- a/LieGroups/SE3/Quat/exp_map.mo
+++ b/LieGroups/SE3/Quat/exp_map.mo
@@ -1,0 +1,26 @@
+within LieGroups.SE3.Quat;
+function exp_map "Exponential map: se(3) -> SE(3)"
+  input Real xi[6] "Lie algebra {vx,vy,vz, omega_x,omega_y,omega_z}";
+  output Real X[7] "Group element {px,py,pz, qw,qx,qy,qz}";
+protected
+  Real v[3] "Translational component";
+  Real omega[3] "Rotational component";
+  Real J[3,3] "SO(3) left Jacobian";
+  Real q[4] "Rotation quaternion";
+algorithm
+  v := xi[1:3];
+  omega := xi[4:6];
+
+  // p = J_l(omega) * v
+  J := LieGroups.SO3.Quat.left_jacobian(omega);
+  X[1] := J[1,1]*v[1] + J[1,2]*v[2] + J[1,3]*v[3];
+  X[2] := J[2,1]*v[1] + J[2,2]*v[2] + J[2,3]*v[3];
+  X[3] := J[3,1]*v[1] + J[3,2]*v[2] + J[3,3]*v[3];
+
+  // q = exp_SO3(omega)
+  q := LieGroups.SO3.Quat.exp_map(omega);
+  X[4] := q[1];
+  X[5] := q[2];
+  X[6] := q[3];
+  X[7] := q[4];
+end exp_map;

--- a/LieGroups/SE3/Quat/inverse.mo
+++ b/LieGroups/SE3/Quat/inverse.mo
@@ -1,0 +1,19 @@
+within LieGroups.SE3.Quat;
+function inverse "SE(3) inverse"
+  input Real X[7] "{p, q}";
+  output Real X_inv[7] "{p_inv, q_inv}";
+protected
+  Real q_inv[4];
+  Real p_rot[3];
+algorithm
+  q_inv := LieGroups.SO3.Quat.inverse(X[4:7]);
+  // p_inv = -R^T * p = -R(q_inv) * p
+  p_rot := LieGroups.SO3.Quat.rotate(q_inv, X[1:3]);
+  X_inv[1] := -p_rot[1];
+  X_inv[2] := -p_rot[2];
+  X_inv[3] := -p_rot[3];
+  X_inv[4] := q_inv[1];
+  X_inv[5] := q_inv[2];
+  X_inv[6] := q_inv[3];
+  X_inv[7] := q_inv[4];
+end inverse;

--- a/LieGroups/SE3/Quat/left_Q.mo
+++ b/LieGroups/SE3/Quat/left_Q.mo
@@ -1,0 +1,69 @@
+within LieGroups.SE3.Quat;
+function left_Q "Barfoot Q-matrix: off-diagonal block of the SE(3) left Jacobian"
+  input Real rho[3] "Translational algebra part";
+  input Real omega[3] "Rotation algebra part";
+  output Real Q[3,3] "3x3 Q matrix";
+protected
+  Real theta_sq;
+  Real theta;
+  Real C1 "(t - sin t)/t^3";
+  Real C2 "(t^2 + 2 cos t - 2)/(2 t^4)";
+  Real C3 "(t cos t + 2 t - 3 sin t)/(2 t^5)";
+  Real C4 "(t^2 + t sin t + 4 cos t - 4)/(2 t^6)";
+  Real C5 "(2 - 2 cos t - t sin t)/(2 t^4)";
+  Real V[3,3]  "[rho]x";
+  Real O[3,3]  "[omega]x";
+  Real O2[3,3], OV[3,3], VO[3,3], O2V[3,3], VO2[3,3];
+  Real OVO2[3,3], O2VO[3,3], O2VO2[3,3], OVO[3,3];
+  Real s, ct, st;
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := omega[1]^2 + omega[2]^2 + omega[3]^2;
+  s := theta_sq;
+  if theta_sq < eps then
+    // Taylor series in s = theta^2 (near identity)
+    C1 := 1.0/6.0    - s/120.0    + s*s/5040.0;
+    C2 := 1.0/24.0   - s/720.0    + s*s/40320.0;
+    C3 := 1.0/120.0  - s/2520.0   + s*s/120960.0;
+    C4 := 1.0/720.0  - s/20160.0  + s*s/1209600.0;
+    C5 := 1.0/24.0   - s/360.0    + s*s/13440.0;
+  else
+    // NaN-safe: max(theta_sq, eps) is exact when this branch is taken (theta_sq >= eps)
+    // and keeps the closed form finite under both-branch/AD evaluation at theta_sq = 0.
+    s := max(theta_sq, eps);
+    theta := sqrt(s);
+    ct := cos(theta);
+    st := sin(theta);
+    C1 := (theta - st) / (s*theta);
+    C2 := (s + 2.0*ct - 2.0) / (2.0*s^2);
+    C3 := (theta*ct + 2.0*theta - 3.0*st) / (2.0*s^2*theta);
+    C4 := (s + theta*st + 4.0*ct - 4.0) / (2.0*s^3);
+    C5 := (2.0 - 2.0*ct - theta*st) / (2.0*s^2);
+  end if;
+
+  V := LieGroups.SO3.Quat.wedge(rho);
+  O := LieGroups.SO3.Quat.wedge(omega);
+  O2 := O*O;
+  OV := O*V;
+  VO := V*O;
+  O2V := O2*V;
+  VO2 := V*O2;
+  OVO := OV*O;
+  OVO2 := OV*O2;
+  O2VO := O2V*O;
+  O2VO2 := O2V*O2;
+
+  Q := 0.5*V
+       + C1*(OV + VO)
+       + C2*(O2V + VO2)
+       + C3*(OVO2 + O2VO)
+       + C4*(O2VO2)
+       + C5*(OVO);
+
+  annotation(Documentation(info="<html>
+    <p>SE(3) left-Jacobian Q block (Barfoot). The SE(3) left Jacobian is
+    [[J_l(omega), Q],[0, J_l(omega)]]. Used to assemble the SE_2(3) left Jacobian.</p>
+    <p>Q = (1/2)[rho]x + C1([w][rho]+[rho][w]) + C2([w]^2[rho]+[rho][w]^2)
+       + C3([w][rho][w]^2+[w]^2[rho][w]) + C4([w]^2[rho][w]^2) + C5([w][rho][w])</p>
+  </html>"));
+end left_Q;

--- a/LieGroups/SE3/Quat/log_map.mo
+++ b/LieGroups/SE3/Quat/log_map.mo
@@ -1,0 +1,30 @@
+within LieGroups.SE3.Quat;
+function log_map "Logarithmic map: SE(3) -> se(3)"
+  input Real X[7] "Group element {px,py,pz, qw,qx,qy,qz}";
+  output Real xi[6] "Lie algebra {vx,vy,vz, omega_x,omega_y,omega_z}";
+protected
+  Real omega[3];
+  Real J_inv[3,3];
+  Real theta_sq;
+  constant Real eps = 1e-8;
+algorithm
+  // omega = log_SO3(q)
+  omega := LieGroups.SO3.Quat.log_map(X[4:7]);
+  xi[4] := omega[1];
+  xi[5] := omega[2];
+  xi[6] := omega[3];
+
+  // v = J_l^{-1}(omega) * p
+  theta_sq := omega[1]^2 + omega[2]^2 + omega[3]^2;
+  if theta_sq < eps then
+    // Near identity: J_l^{-1} ~ I, so v ~ p
+    xi[1] := X[1];
+    xi[2] := X[2];
+    xi[3] := X[3];
+  else
+    J_inv := LieGroups.SO3.Quat.left_jacobian_inv(omega);
+    xi[1] := J_inv[1,1]*X[1] + J_inv[1,2]*X[2] + J_inv[1,3]*X[3];
+    xi[2] := J_inv[2,1]*X[1] + J_inv[2,2]*X[2] + J_inv[2,3]*X[3];
+    xi[3] := J_inv[3,1]*X[1] + J_inv[3,2]*X[2] + J_inv[3,3]*X[3];
+  end if;
+end log_map;

--- a/LieGroups/SE3/Quat/package.mo
+++ b/LieGroups/SE3/Quat/package.mo
@@ -1,0 +1,7 @@
+within LieGroups.SE3;
+package Quat "SE(3) with quaternion rotation parameterization"
+  annotation(Documentation(info="<html>
+    <p>Group element: X = {px, py, pz, qw, qx, qy, qz} (7 params).</p>
+    <p>Lie algebra: xi = {vx, vy, vz, omega_x, omega_y, omega_z} (6 params, translation-first).</p>
+  </html>"));
+end Quat;

--- a/LieGroups/SE3/Quat/product.mo
+++ b/LieGroups/SE3/Quat/product.mo
@@ -1,0 +1,22 @@
+within LieGroups.SE3.Quat;
+function product "SE(3) group product"
+  input Real X1[7] "{p1, q1} = {px,py,pz, qw,qx,qy,qz}";
+  input Real X2[7] "{p2, q2}";
+  output Real X[7] "{p, q}";
+protected
+  Real p_rot[3];
+  Real q_prod[4];
+algorithm
+  // p = R(q1)*p2 + p1
+  p_rot := LieGroups.SO3.Quat.rotate(X1[4:7], X2[1:3]);
+  X[1] := p_rot[1] + X1[1];
+  X[2] := p_rot[2] + X1[2];
+  X[3] := p_rot[3] + X1[3];
+
+  // q = q1 * q2
+  q_prod := LieGroups.SO3.Quat.product(X1[4:7], X2[4:7]);
+  X[4] := q_prod[1];
+  X[5] := q_prod[2];
+  X[6] := q_prod[3];
+  X[7] := q_prod[4];
+end product;

--- a/LieGroups/SE3/Quat/small_adjoint.mo
+++ b/LieGroups/SE3/Quat/small_adjoint.mo
@@ -1,0 +1,21 @@
+within LieGroups.SE3.Quat;
+function small_adjoint "Small adjoint ad_xi for se(3), translation-first ordering"
+  input Real xi[6] "Lie algebra {vx,vy,vz, omega_x,omega_y,omega_z}";
+  output Real ad[6,6] "6x6 small adjoint matrix";
+protected
+  Real vx[3,3] "Skew [v]x";
+  Real wx[3,3] "Skew [omega]x";
+algorithm
+  vx := LieGroups.SO3.Quat.wedge(xi[1:3]);
+  wx := LieGroups.SO3.Quat.wedge(xi[4:6]);
+
+  // ad = {{[omega]x, [v]x}, {0, [omega]x}}
+  for i in 1:3 loop
+    for j in 1:3 loop
+      ad[i,j] := wx[i,j];
+      ad[i,j+3] := vx[i,j];
+      ad[i+3,j] := 0;
+      ad[i+3,j+3] := wx[i,j];
+    end for;
+  end for;
+end small_adjoint;

--- a/LieGroups/SE3/Quat/to_Matrix.mo
+++ b/LieGroups/SE3/Quat/to_Matrix.mo
@@ -1,0 +1,16 @@
+within LieGroups.SE3.Quat;
+function to_Matrix "Convert SE(3) element to 4x4 homogeneous matrix"
+  input Real X[7] "{px,py,pz, qw,qx,qy,qz}";
+  output Real M[4,4] "4x4 matrix {{R, p}, {0, 1}}";
+protected
+  Real R[3,3];
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(X[4:7]);
+  for i in 1:3 loop
+    for j in 1:3 loop
+      M[i,j] := R[i,j];
+    end for;
+    M[i,4] := X[i];
+  end for;
+  M[4,1] := 0; M[4,2] := 0; M[4,3] := 0; M[4,4] := 1;
+end to_Matrix;

--- a/LieGroups/SE3/package.mo
+++ b/LieGroups/SE3/package.mo
@@ -1,0 +1,3 @@
+within LieGroups;
+package SE3 "Special Euclidean Group SE(3) — 3D rigid body motions"
+end SE3;

--- a/LieGroups/SO2/exp_map.mo
+++ b/LieGroups/SO2/exp_map.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO2;
+function exp_map "Exponential map: so(2) -> SO(2) (identity map)"
+  input Real omega "Angular velocity [rad]";
+  output Real theta "Rotation angle [rad]";
+algorithm
+  theta := omega;
+end exp_map;

--- a/LieGroups/SO2/from_Matrix.mo
+++ b/LieGroups/SO2/from_Matrix.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO2;
+function from_Matrix "Extract angle from 2x2 rotation matrix"
+  input Real R[2,2] "2x2 rotation matrix";
+  output Real theta "Rotation angle [rad]";
+algorithm
+  theta := atan2(R[2,1], R[1,1]);
+end from_Matrix;

--- a/LieGroups/SO2/inverse.mo
+++ b/LieGroups/SO2/inverse.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO2;
+function inverse "SO(2) inverse: negate angle"
+  input Real a "Rotation angle [rad]";
+  output Real a_inv "Inverse angle [rad]";
+algorithm
+  a_inv := -a;
+end inverse;

--- a/LieGroups/SO2/log_map.mo
+++ b/LieGroups/SO2/log_map.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO2;
+function log_map "Logarithmic map: SO(2) -> so(2) (identity map)"
+  input Real theta "Rotation angle [rad]";
+  output Real omega "Angular velocity [rad]";
+algorithm
+  omega := theta;
+end log_map;

--- a/LieGroups/SO2/package.mo
+++ b/LieGroups/SO2/package.mo
@@ -1,0 +1,3 @@
+within LieGroups;
+package SO2 "Special Orthogonal Group SO(2) — 2D rotations, parameterized by angle theta"
+end SO2;

--- a/LieGroups/SO2/product.mo
+++ b/LieGroups/SO2/product.mo
@@ -1,0 +1,8 @@
+within LieGroups.SO2;
+function product "SO(2) group product: angle addition"
+  input Real a "Left rotation angle [rad]";
+  input Real b "Right rotation angle [rad]";
+  output Real c "Result rotation angle [rad]";
+algorithm
+  c := a + b;
+end product;

--- a/LieGroups/SO2/rotate.mo
+++ b/LieGroups/SO2/rotate.mo
@@ -1,0 +1,13 @@
+within LieGroups.SO2;
+function rotate "Rotate a 2D vector by angle theta"
+  input Real theta "Rotation angle [rad]";
+  input Real v[2] "Input vector";
+  output Real v_out[2] "Rotated vector";
+protected
+  Real c, s;
+algorithm
+  c := cos(theta);
+  s := sin(theta);
+  v_out[1] := c*v[1] - s*v[2];
+  v_out[2] := s*v[1] + c*v[2];
+end rotate;

--- a/LieGroups/SO2/to_Matrix.mo
+++ b/LieGroups/SO2/to_Matrix.mo
@@ -1,0 +1,11 @@
+within LieGroups.SO2;
+function to_Matrix "Convert angle to 2x2 rotation matrix"
+  input Real theta "Rotation angle [rad]";
+  output Real R[2,2] "2x2 rotation matrix";
+protected
+  Real c, s;
+algorithm
+  c := cos(theta);
+  s := sin(theta);
+  R := {{c, -s}, {s, c}};
+end to_Matrix;

--- a/LieGroups/SO3/Dcm/exp_map.mo
+++ b/LieGroups/SO3/Dcm/exp_map.mo
@@ -1,0 +1,38 @@
+within LieGroups.SO3.Dcm;
+function exp_map "Exponential map: so(3) vector -> DCM via Rodriguez formula"
+  input Real v[3] "Rotation vector (axis * angle)";
+  output Real R[3,3] "Rotation matrix";
+protected
+  Real theta_sq, theta;
+  Real A "sin(theta)/theta";
+  Real B "(1 - cos(theta))/theta^2";
+  Real S[3,3] "Skew [v]x";
+  Real S2[3,3] "[v]x^2";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  S := {{0, -v[3], v[2]},
+        {v[3], 0, -v[1]},
+        {-v[2], v[1], 0}};
+
+  S2 := {{-(v[2]^2 + v[3]^2), v[1]*v[2], v[1]*v[3]},
+         {v[1]*v[2], -(v[1]^2 + v[3]^2), v[2]*v[3]},
+         {v[1]*v[3], v[2]*v[3], -(v[1]^2 + v[2]^2)}};
+
+  if theta_sq < eps then
+    A := 1.0 - theta_sq / 6.0;
+    B := 0.5 - theta_sq / 24.0;
+  else
+    theta := sqrt(theta_sq);
+    A := sin(theta) / theta;
+    B := (1.0 - cos(theta)) / theta_sq;
+  end if;
+
+  // R = I + A*[v]x + B*[v]x^2
+  for i in 1:3 loop
+    for j in 1:3 loop
+      R[i,j] := (if i == j then 1.0 else 0.0) + A * S[i,j] + B * S2[i,j];
+    end for;
+  end for;
+end exp_map;

--- a/LieGroups/SO3/Dcm/from_Quat.mo
+++ b/LieGroups/SO3/Dcm/from_Quat.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO3.Dcm;
+function from_Quat "Convert quaternion to DCM (alias for Quat.to_DCM)"
+  input Real q[4] "Quaternion {w,x,y,z}";
+  output Real R[3,3] "Rotation matrix";
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(q);
+end from_Quat;

--- a/LieGroups/SO3/Dcm/inverse.mo
+++ b/LieGroups/SO3/Dcm/inverse.mo
@@ -1,0 +1,11 @@
+within LieGroups.SO3.Dcm;
+function inverse "SO(3) DCM inverse: transpose"
+  input Real R[3,3];
+  output Real R_inv[3,3];
+algorithm
+  for i in 1:3 loop
+    for j in 1:3 loop
+      R_inv[i,j] := R[j,i];
+    end for;
+  end for;
+end inverse;

--- a/LieGroups/SO3/Dcm/log_map.mo
+++ b/LieGroups/SO3/Dcm/log_map.mo
@@ -1,0 +1,27 @@
+within LieGroups.SO3.Dcm;
+function log_map "Logarithmic map: DCM -> so(3) rotation vector"
+  input Real R[3,3] "Rotation matrix";
+  output Real v[3] "Rotation vector";
+protected
+  Real tr;
+  Real cos_theta;
+  Real theta;
+  Real A "theta / (2*sin(theta))";
+  constant Real eps = 1e-8;
+algorithm
+  tr := R[1,1] + R[2,2] + R[3,3];
+  cos_theta := min(max((tr - 1.0) / 2.0, -1.0), 1.0);
+  theta := acos(cos_theta);
+
+  if abs(theta) < eps then
+    // Near identity: A ~ 0.5 + theta^2/12
+    A := 0.5 + theta^2 / 12.0;
+  else
+    A := theta / (2.0 * sin(theta));
+  end if;
+
+  // v = A * vee(R - R^T)
+  v[1] := A * (R[3,2] - R[2,3]);
+  v[2] := A * (R[1,3] - R[3,1]);
+  v[3] := A * (R[2,1] - R[1,2]);
+end log_map;

--- a/LieGroups/SO3/Dcm/package.mo
+++ b/LieGroups/SO3/Dcm/package.mo
@@ -1,0 +1,3 @@
+within LieGroups.SO3;
+package Dcm "SO(3) Direction Cosine Matrix parameterization"
+end Dcm;

--- a/LieGroups/SO3/Dcm/product.mo
+++ b/LieGroups/SO3/Dcm/product.mo
@@ -1,0 +1,12 @@
+within LieGroups.SO3.Dcm;
+function product "SO(3) DCM product: R1 * R2"
+  input Real R1[3,3];
+  input Real R2[3,3];
+  output Real R[3,3];
+algorithm
+  for i in 1:3 loop
+    for j in 1:3 loop
+      R[i,j] := R1[i,1]*R2[1,j] + R1[i,2]*R2[2,j] + R1[i,3]*R2[3,j];
+    end for;
+  end for;
+end product;

--- a/LieGroups/SO3/Dcm/to_Quat.mo
+++ b/LieGroups/SO3/Dcm/to_Quat.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO3.Dcm;
+function to_Quat "Convert DCM to quaternion (alias for Quat.from_DCM)"
+  input Real R[3,3] "Rotation matrix";
+  output Real q[4] "Quaternion {w,x,y,z}";
+algorithm
+  q := LieGroups.SO3.Quat.from_DCM(R);
+end to_Quat;

--- a/LieGroups/SO3/EulerB321/from_Quat.mo
+++ b/LieGroups/SO3/EulerB321/from_Quat.mo
@@ -1,0 +1,25 @@
+within LieGroups.SO3.EulerB321;
+function from_Quat "Convert quaternion to Euler B321 angles {yaw, pitch, roll}"
+  input Real q[4] "Unit quaternion {w,x,y,z}";
+  output Real euler[3] "{yaw (psi), pitch (theta), roll (phi)} [rad]";
+protected
+  Real a, b, c, d;
+  Real sinp;
+algorithm
+  a := q[1]; b := q[2]; c := q[3]; d := q[4];
+
+  // Pitch: theta = asin(2*(ac - bd))
+  sinp := 2.0*(a*c - d*b);
+  sinp := min(max(sinp, -1.0), 1.0);
+
+  if abs(sinp) > 0.9999 then
+    // Gimbal lock: pitch near +/- 90 deg
+    euler[2] := asin(sinp);
+    euler[3] := 0.0;
+    euler[1] := atan2(2.0*(b*c + a*d), 1.0 - 2.0*(c*c + d*d));
+  else
+    euler[1] := atan2(2.0*(a*d + b*c), 1.0 - 2.0*(c*c + d*d));
+    euler[2] := asin(sinp);
+    euler[3] := atan2(2.0*(a*b + c*d), 1.0 - 2.0*(b*b + c*c));
+  end if;
+end from_Quat;

--- a/LieGroups/SO3/EulerB321/package.mo
+++ b/LieGroups/SO3/EulerB321/package.mo
@@ -1,0 +1,3 @@
+within LieGroups.SO3;
+package EulerB321 "Body-fixed Z-Y-X (3-2-1) Euler angles: {yaw, pitch, roll}"
+end EulerB321;

--- a/LieGroups/SO3/EulerB321/to_Quat.mo
+++ b/LieGroups/SO3/EulerB321/to_Quat.mo
@@ -1,0 +1,20 @@
+within LieGroups.SO3.EulerB321;
+function to_Quat "Convert Euler B321 angles to quaternion via half-angle formula"
+  input Real euler[3] "{yaw (psi), pitch (theta), roll (phi)} [rad]";
+  output Real q[4] "Unit quaternion {w,x,y,z}";
+protected
+  Real cy, sy, cp, sp, cr, sr;
+algorithm
+  cy := cos(euler[1] / 2.0);
+  sy := sin(euler[1] / 2.0);
+  cp := cos(euler[2] / 2.0);
+  sp := sin(euler[2] / 2.0);
+  cr := cos(euler[3] / 2.0);
+  sr := sin(euler[3] / 2.0);
+
+  // q = qz(yaw) * qy(pitch) * qx(roll)
+  q[1] := cy*cp*cr + sy*sp*sr;
+  q[2] := cy*cp*sr - sy*sp*cr;
+  q[3] := cy*sp*cr + sy*cp*sr;
+  q[4] := sy*cp*cr - cy*sp*sr;
+end to_Quat;

--- a/LieGroups/SO3/Mrp/exp_map.mo
+++ b/LieGroups/SO3/Mrp/exp_map.mo
@@ -1,0 +1,27 @@
+within LieGroups.SO3.Mrp;
+function exp_map "Exponential map: so(3) vector -> MRP"
+  input Real v[3] "Rotation vector (axis * angle)";
+  output Real r[3] "MRP parameters";
+protected
+  Real theta_sq, theta;
+  Real A "tan(theta/4) / theta";
+  Real n_sq;
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  if theta_sq < eps then
+    // Taylor: tan(t/4)/t ~ 1/4 + t^2/192
+    A := 0.25 + theta_sq / 192.0;
+  else
+    theta := sqrt(theta_sq);
+    A := tan(theta / 4.0) / theta;
+  end if;
+
+  r := A * v;
+
+  // Shadow switch if ||r|| > 1. If-EXPRESSION (not a no-else if-statement) so
+  // AD/both-branch compilers evaluate the condition correctly.
+  n_sq := r[1]^2 + r[2]^2 + r[3]^2;
+  r := if n_sq > 1.0 then LieGroups.SO3.Mrp.shadow(r) else r;
+end exp_map;

--- a/LieGroups/SO3/Mrp/from_Quat.mo
+++ b/LieGroups/SO3/Mrp/from_Quat.mo
@@ -1,0 +1,21 @@
+within LieGroups.SO3.Mrp;
+function from_Quat "Convert quaternion to MRP"
+  input Real q[4] "Quaternion {w,x,y,z}";
+  output Real r[3] "MRP parameters";
+protected
+  Real q_n[4];
+  Real den;
+  constant Real eps = 1e-10;
+algorithm
+  // Ensure positive scalar part
+  if q[1] < 0 then
+    q_n := -q;
+  else
+    q_n := q;
+  end if;
+
+  den := max(1.0 + q_n[1], eps);
+  r[1] := q_n[2] / den;
+  r[2] := q_n[3] / den;
+  r[3] := q_n[4] / den;
+end from_Quat;

--- a/LieGroups/SO3/Mrp/inverse.mo
+++ b/LieGroups/SO3/Mrp/inverse.mo
@@ -1,0 +1,7 @@
+within LieGroups.SO3.Mrp;
+function inverse "MRP inverse: -r"
+  input Real r[3];
+  output Real r_inv[3];
+algorithm
+  r_inv := -r;
+end inverse;

--- a/LieGroups/SO3/Mrp/log_map.mo
+++ b/LieGroups/SO3/Mrp/log_map.mo
@@ -1,0 +1,21 @@
+within LieGroups.SO3.Mrp;
+function log_map "Logarithmic map: MRP -> so(3) rotation vector"
+  input Real r[3] "MRP parameters";
+  output Real v[3] "Rotation vector";
+protected
+  Real n_sq, n;
+  Real A "4*atan(||r||) / ||r||";
+  constant Real eps = 1e-10;
+algorithm
+  n_sq := r[1]^2 + r[2]^2 + r[3]^2;
+
+  if n_sq < eps then
+    // Taylor: 4*atan(n)/n ~ 4 - 4*n^2/3
+    A := 4.0 - 4.0*n_sq/3.0;
+  else
+    n := sqrt(n_sq);
+    A := 4.0 * atan(n) / n;
+  end if;
+
+  v := A * r;
+end log_map;

--- a/LieGroups/SO3/Mrp/package.mo
+++ b/LieGroups/SO3/Mrp/package.mo
@@ -1,0 +1,3 @@
+within LieGroups.SO3;
+package Mrp "SO(3) Modified Rodrigues Parameters — 3-parameter, singularity-free with shadow"
+end Mrp;

--- a/LieGroups/SO3/Mrp/product.mo
+++ b/LieGroups/SO3/Mrp/product.mo
@@ -1,0 +1,31 @@
+within LieGroups.SO3.Mrp;
+function product "MRP composition"
+  input Real a[3] "Left MRP";
+  input Real b[3] "Right MRP";
+  output Real r[3] "Result MRP";
+protected
+  Real na_sq, nb_sq, dot_ab, denom;
+  Real cross_ba[3];
+  Real n_sq;
+algorithm
+  na_sq := a[1]^2 + a[2]^2 + a[3]^2;
+  nb_sq := b[1]^2 + b[2]^2 + b[3]^2;
+  dot_ab := a[1]*b[1] + a[2]*b[2] + a[3]*b[3];
+
+  // cross(b, a)
+  cross_ba := {b[2]*a[3] - b[3]*a[2],
+               b[3]*a[1] - b[1]*a[3],
+               b[1]*a[2] - b[2]*a[1]};
+
+  denom := 1.0 + na_sq*nb_sq - 2.0*dot_ab;
+  if abs(denom) < 1e-10 then
+    denom := 1e-10;
+  end if;
+
+  r := ((1.0 - na_sq)*b + (1.0 - nb_sq)*a - 2.0*cross_ba) / denom;
+
+  // Shadow switch if ||r|| > 1. If-EXPRESSION (not a no-else if-statement) so
+  // AD/both-branch compilers evaluate the condition correctly.
+  n_sq := r[1]^2 + r[2]^2 + r[3]^2;
+  r := if n_sq > 1.0 then LieGroups.SO3.Mrp.shadow(r) else r;
+end product;

--- a/LieGroups/SO3/Mrp/shadow.mo
+++ b/LieGroups/SO3/Mrp/shadow.mo
@@ -1,0 +1,11 @@
+within LieGroups.SO3.Mrp;
+function shadow "MRP shadow transformation: r_s = -r / ||r||^2"
+  input Real r[3] "MRP parameters";
+  output Real r_s[3] "Shadow MRP parameters";
+protected
+  Real n_sq;
+  constant Real eps = 1e-10;
+algorithm
+  n_sq := max(r[1]^2 + r[2]^2 + r[3]^2, eps);
+  r_s := -r / n_sq;
+end shadow;

--- a/LieGroups/SO3/Mrp/to_DCM.mo
+++ b/LieGroups/SO3/Mrp/to_DCM.mo
@@ -1,0 +1,29 @@
+within LieGroups.SO3.Mrp;
+function to_DCM "Convert MRP to rotation matrix"
+  input Real r[3] "MRP parameters";
+  output Real R[3,3] "Rotation matrix";
+protected
+  Real n_sq;
+  Real den_sq;
+  Real S[3,3] "Skew [r]x";
+  Real S2[3,3] "[r]x^2";
+algorithm
+  n_sq := r[1]^2 + r[2]^2 + r[3]^2;
+  den_sq := (1.0 + n_sq) * (1.0 + n_sq);
+
+  S := {{0, -r[3], r[2]},
+        {r[3], 0, -r[1]},
+        {-r[2], r[1], 0}};
+
+  S2 := {{-(r[2]^2 + r[3]^2), r[1]*r[2], r[1]*r[3]},
+         {r[1]*r[2], -(r[1]^2 + r[3]^2), r[2]*r[3]},
+         {r[1]*r[3], r[2]*r[3], -(r[1]^2 + r[2]^2)}};
+
+  // R = I + (8*S^2 - 4*(1-n_sq)*S) / (1+n_sq)^2
+  for i in 1:3 loop
+    for j in 1:3 loop
+      R[i,j] := (if i == j then 1.0 else 0.0)
+                + (8.0*S2[i,j] - 4.0*(1.0 - n_sq)*S[i,j]) / den_sq;
+    end for;
+  end for;
+end to_DCM;

--- a/LieGroups/SO3/Mrp/to_Quat.mo
+++ b/LieGroups/SO3/Mrp/to_Quat.mo
@@ -1,0 +1,15 @@
+within LieGroups.SO3.Mrp;
+function to_Quat "Convert MRP to quaternion"
+  input Real r[3] "MRP parameters";
+  output Real q[4] "Quaternion {w,x,y,z}";
+protected
+  Real n_sq;
+  Real den;
+algorithm
+  n_sq := r[1]^2 + r[2]^2 + r[3]^2;
+  den := 1.0 + n_sq;
+  q[1] := (1.0 - n_sq) / den;
+  q[2] := 2.0*r[1] / den;
+  q[3] := 2.0*r[2] / den;
+  q[4] := 2.0*r[3] / den;
+end to_Quat;

--- a/LieGroups/SO3/Quat/adjoint.mo
+++ b/LieGroups/SO3/Quat/adjoint.mo
@@ -1,0 +1,13 @@
+within LieGroups.SO3.Quat;
+function adjoint "Adjoint Ad_X: for SO(3), Ad_q = R (the rotation matrix)"
+  input Real q[4] "Unit quaternion {w,x,y,z}";
+  output Real Ad[3,3] "3x3 adjoint matrix (equals the DCM)";
+algorithm
+  Ad := LieGroups.SO3.Quat.to_DCM(q);
+  annotation(Documentation(info="<html>
+    <p>For SO(3), the adjoint representation is simply the rotation matrix:
+    Ad_R(v) = R*v. This rotates Lie algebra elements (angular velocities)
+    from one frame to another.</p>
+    <p>Used in IEKF error propagation: A_k = Ad_{Exp(-xi*dt)}</p>
+  </html>"));
+end adjoint;

--- a/LieGroups/SO3/Quat/exp_map.mo
+++ b/LieGroups/SO3/Quat/exp_map.mo
@@ -1,0 +1,26 @@
+within LieGroups.SO3.Quat;
+function exp_map "Exponential map: so(3) rotation vector -> unit quaternion"
+  input Real v[3] "Rotation vector (axis * angle)";
+  output Real q[4] "Unit quaternion {w,x,y,z}";
+protected
+  Real theta_sq;
+  Real half_theta;
+  Real A "sin(theta/2) / theta";
+  Real B "cos(theta/2)";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+  if theta_sq < eps then
+    // Taylor series: cos(t/2) ~ 1 - t^2/8, sin(t/2)/t ~ 1/2 - t^2/48
+    B := 1.0 - theta_sq / 8.0;
+    A := 0.5 - theta_sq / 48.0;
+  else
+    half_theta := sqrt(theta_sq) / 2.0;
+    B := cos(half_theta);
+    A := sin(half_theta) / sqrt(theta_sq);
+  end if;
+  q[1] := B;
+  q[2] := A * v[1];
+  q[3] := A * v[2];
+  q[4] := A * v[3];
+end exp_map;

--- a/LieGroups/SO3/Quat/from_DCM.mo
+++ b/LieGroups/SO3/Quat/from_DCM.mo
@@ -1,0 +1,45 @@
+within LieGroups.SO3.Quat;
+function from_DCM "Convert 3x3 rotation matrix to unit quaternion (Shepperd's method)"
+  input Real R[3,3] "Rotation matrix";
+  output Real q[4] "Unit quaternion {w,x,y,z}";
+protected
+  Real tr;
+  Real b1, b2, b3, b4;
+  constant Real eps = 1e-10;
+algorithm
+  tr := R[1,1] + R[2,2] + R[3,3];
+
+  if tr > 0 then
+    // Case 1: trace > 0 (w is largest)
+    b1 := 0.5 * sqrt(max(1.0 + tr, eps));
+    q[1] := b1;
+    q[2] := (R[3,2] - R[2,3]) / max(4.0*b1, eps);
+    q[3] := (R[1,3] - R[3,1]) / max(4.0*b1, eps);
+    q[4] := (R[2,1] - R[1,2]) / max(4.0*b1, eps);
+  elseif R[1,1] > R[2,2] and R[1,1] > R[3,3] then
+    // Case 2: R[1,1] is largest diagonal
+    b2 := 0.5 * sqrt(max(1.0 + R[1,1] - R[2,2] - R[3,3], eps));
+    q[1] := (R[3,2] - R[2,3]) / max(4.0*b2, eps);
+    q[2] := b2;
+    q[3] := (R[1,2] + R[2,1]) / max(4.0*b2, eps);
+    q[4] := (R[1,3] + R[3,1]) / max(4.0*b2, eps);
+  elseif R[2,2] > R[3,3] then
+    // Case 3: R[2,2] is largest diagonal
+    b3 := 0.5 * sqrt(max(1.0 - R[1,1] + R[2,2] - R[3,3], eps));
+    q[1] := (R[1,3] - R[3,1]) / max(4.0*b3, eps);
+    q[2] := (R[1,2] + R[2,1]) / max(4.0*b3, eps);
+    q[3] := b3;
+    q[4] := (R[2,3] + R[3,2]) / max(4.0*b3, eps);
+  else
+    // Case 4: R[3,3] is largest diagonal
+    b4 := 0.5 * sqrt(max(1.0 - R[1,1] - R[2,2] + R[3,3], eps));
+    q[1] := (R[2,1] - R[1,2]) / max(4.0*b4, eps);
+    q[2] := (R[1,3] + R[3,1]) / max(4.0*b4, eps);
+    q[3] := (R[2,3] + R[3,2]) / max(4.0*b4, eps);
+    q[4] := b4;
+  end if;
+
+  // Ensure positive w convention. If-EXPRESSION (not a no-else if-statement) so
+  // AD/both-branch compilers evaluate the condition correctly.
+  q := if q[1] < 0 then -q else q;
+end from_DCM;

--- a/LieGroups/SO3/Quat/inverse.mo
+++ b/LieGroups/SO3/Quat/inverse.mo
@@ -1,0 +1,10 @@
+within LieGroups.SO3.Quat;
+function inverse "Quaternion inverse (conjugate for unit quaternions)"
+  input Real q[4] "{w,x,y,z}";
+  output Real q_inv[4] "{w,-x,-y,-z}";
+algorithm
+  q_inv[1] :=  q[1];
+  q_inv[2] := -q[2];
+  q_inv[3] := -q[3];
+  q_inv[4] := -q[4];
+end inverse;

--- a/LieGroups/SO3/Quat/kinematics.mo
+++ b/LieGroups/SO3/Quat/kinematics.mo
@@ -1,0 +1,11 @@
+within LieGroups.SO3.Quat;
+function kinematics "Quaternion kinematics: q_dot = 0.5 * q * [0, omega]"
+  input Real q[4] "Unit quaternion {w,x,y,z}";
+  input Real omega[3] "Body-frame angular velocity {p,q,r}";
+  output Real q_dot[4] "Time derivative of quaternion";
+algorithm
+  q_dot[1] := 0.5 * (-q[2]*omega[1] - q[3]*omega[2] - q[4]*omega[3]);
+  q_dot[2] := 0.5 * ( q[1]*omega[1] - q[4]*omega[2] + q[3]*omega[3]);
+  q_dot[3] := 0.5 * ( q[4]*omega[1] + q[1]*omega[2] - q[2]*omega[3]);
+  q_dot[4] := 0.5 * (-q[3]*omega[1] + q[2]*omega[2] + q[1]*omega[3]);
+end kinematics;

--- a/LieGroups/SO3/Quat/left_jacobian.mo
+++ b/LieGroups/SO3/Quat/left_jacobian.mo
@@ -1,0 +1,53 @@
+within LieGroups.SO3.Quat;
+function left_jacobian "Left Jacobian J_l(v) of SO(3)"
+  input Real v[3] "Rotation vector";
+  output Real J[3,3] "3x3 left Jacobian matrix";
+protected
+  Real theta_sq;
+  Real A "(1 - cos(theta)) / theta^2";
+  Real B "(theta - sin(theta)) / theta^3";
+  Real theta;
+  Real S[3,3] "Skew-symmetric [v]x";
+  Real S2[3,3] "[v]x * [v]x";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  // Skew-symmetric matrix [v]x
+  S := {{0, -v[3], v[2]},
+        {v[3], 0, -v[1]},
+        {-v[2], v[1], 0}};
+
+  // [v]x^2
+  S2 := {{-(v[2]^2 + v[3]^2), v[1]*v[2], v[1]*v[3]},
+         {v[1]*v[2], -(v[1]^2 + v[3]^2), v[2]*v[3]},
+         {v[1]*v[3], v[2]*v[3], -(v[1]^2 + v[2]^2)}};
+
+  if theta_sq < eps then
+    // Taylor series: (1-cos t)/t^2 ~ 1/2 - t^2/24
+    A := 0.5 - theta_sq / 24.0;
+    // Taylor series: (t-sin t)/t^3 ~ 1/6 - t^2/120
+    B := 1.0/6.0 - theta_sq / 120.0;
+  else
+    // NaN-safe denominator: this branch is only selected for theta_sq >= eps, so
+    // max(theta_sq, eps) is exact when taken, but keeps the closed form finite when
+    // an AD/both-branch evaluator (e.g. rumoca) evaluates it at theta_sq = 0.
+    theta := sqrt(max(theta_sq, eps));
+    A := (1.0 - cos(theta)) / (theta * theta);
+    B := (theta - sin(theta)) / (theta * theta * theta);
+  end if;
+
+  // J_l = I + A * [v]x + B * [v]x^2
+  for i in 1:3 loop
+    for j in 1:3 loop
+      J[i,j] := (if i == j then 1.0 else 0.0) + A * S[i,j] + B * S2[i,j];
+    end for;
+  end for;
+
+  annotation(Documentation(info="<html>
+    <p>Left Jacobian of SO(3): J_l(v) = I + ((1-cos θ)/θ²)[v]× + ((θ-sin θ)/θ³)[v]×²</p>
+    <p>Relates body-frame perturbations to group perturbations:
+    Exp((v + δv)^) ≈ Exp(v^) * Exp((J_l(v) δv)^)</p>
+    <p>Used in the V(ω) matrix for SE(3) exponential map.</p>
+  </html>"));
+end left_jacobian;

--- a/LieGroups/SO3/Quat/left_jacobian_inv.mo
+++ b/LieGroups/SO3/Quat/left_jacobian_inv.mo
@@ -1,0 +1,47 @@
+within LieGroups.SO3.Quat;
+function left_jacobian_inv "Inverse left Jacobian J_l^{-1}(v) of SO(3)"
+  input Real v[3] "Rotation vector";
+  output Real J_inv[3,3] "3x3 inverse left Jacobian matrix";
+protected
+  Real theta_sq;
+  Real C "1/theta^2 + sin(theta)/(2*theta*(cos(theta)-1))";
+  Real theta;
+  Real S[3,3] "Skew-symmetric [v]x";
+  Real S2[3,3] "[v]x * [v]x";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  // Skew-symmetric matrix [v]x
+  S := {{0, -v[3], v[2]},
+        {v[3], 0, -v[1]},
+        {-v[2], v[1], 0}};
+
+  // [v]x^2
+  S2 := {{-(v[2]^2 + v[3]^2), v[1]*v[2], v[1]*v[3]},
+         {v[1]*v[2], -(v[1]^2 + v[3]^2), v[2]*v[3]},
+         {v[1]*v[3], v[2]*v[3], -(v[1]^2 + v[2]^2)}};
+
+  if theta_sq < eps then
+    // Taylor series: 1/t^2 + sin(t)/(2t(cos(t)-1)) ~ 1/12 + t^2/720
+    C := 1.0/12.0 + theta_sq / 720.0;
+  else
+    // NaN-safe: max(theta_sq, eps) is exact when this branch is taken (theta_sq >= eps)
+    // and keeps the closed form finite under both-branch/AD evaluation at theta_sq = 0.
+    theta := sqrt(max(theta_sq, eps));
+    C := 1.0 / (theta * theta) + sin(theta) / (2.0 * theta * (cos(theta) - 1.0));
+  end if;
+
+  // J_l^{-1} = I - 0.5 * [v]x + C * [v]x^2
+  for i in 1:3 loop
+    for j in 1:3 loop
+      J_inv[i,j] := (if i == j then 1.0 else 0.0) - 0.5 * S[i,j] + C * S2[i,j];
+    end for;
+  end for;
+
+  annotation(Documentation(info="<html>
+    <p>Inverse left Jacobian of SO(3): J_l^{-1}(v) = I - ½[v]× + C·[v]×²</p>
+    <p>where C = 1/θ² + sin(θ)/(2θ(cos(θ)-1))</p>
+    <p>Used in the SE(3) logarithm map: V(ω)^{-1} recovers translation from the group element.</p>
+  </html>"));
+end left_jacobian_inv;

--- a/LieGroups/SO3/Quat/log_map.mo
+++ b/LieGroups/SO3/Quat/log_map.mo
@@ -1,0 +1,39 @@
+within LieGroups.SO3.Quat;
+function log_map "Logarithmic map: unit quaternion -> so(3) rotation vector"
+  input Real q[4] "Unit quaternion {w,x,y,z}";
+  output Real v[3] "Rotation vector (axis * angle)";
+protected
+  Real q_n[4];
+  Real qw;
+  Real vec_norm;
+  Real theta;
+  Real A;
+  constant Real eps = 1e-10;
+algorithm
+  // Normalize input
+  q_n := LieGroups.SO3.Quat.normalize(q);
+
+  // Ensure positive scalar part (shortest path). Written as an if-EXPRESSION
+  // (not a no-else if-statement) so AD/both-branch compilers evaluate it correctly.
+  q_n := if q_n[1] < 0 then -q_n else q_n;
+
+  qw := min(max(q_n[1], -1.0), 1.0);
+  vec_norm := sqrt(q_n[2]^2 + q_n[3]^2 + q_n[4]^2);
+
+  if vec_norm < eps then
+    // Near identity: theta ~ 2*||qvec||, so v ~ 2*qvec
+    v[1] := 2.0 * q_n[2];
+    v[2] := 2.0 * q_n[3];
+    v[3] := 2.0 * q_n[4];
+  else
+    // theta = 2*atan2(||qvec||, qw): well-conditioned for all angles
+    // (acos(qw) loses precision near identity, where qw -> 1).
+    theta := 2.0 * atan2(vec_norm, qw);
+    // NaN-safe: this branch is only selected for vec_norm >= eps, so max(vec_norm, eps)
+    // is exact when taken, but keeps A finite under both-branch/AD evaluation at vec_norm = 0.
+    A := theta / max(vec_norm, eps);
+    v[1] := A * q_n[2];
+    v[2] := A * q_n[3];
+    v[3] := A * q_n[4];
+  end if;
+end log_map;

--- a/LieGroups/SO3/Quat/normalize.mo
+++ b/LieGroups/SO3/Quat/normalize.mo
@@ -1,0 +1,10 @@
+within LieGroups.SO3.Quat;
+function normalize "Normalize quaternion to unit length"
+  input Real q[4];
+  output Real q_n[4];
+protected
+  Real n;
+algorithm
+  n := max(sqrt(q[1]^2 + q[2]^2 + q[3]^2 + q[4]^2), 1e-10);
+  q_n := q / n;
+end normalize;

--- a/LieGroups/SO3/Quat/package.mo
+++ b/LieGroups/SO3/Quat/package.mo
@@ -1,0 +1,3 @@
+within LieGroups.SO3;
+package Quat "SO(3) quaternion parameterization — q = {w, x, y, z}"
+end Quat;

--- a/LieGroups/SO3/Quat/product.mo
+++ b/LieGroups/SO3/Quat/product.mo
@@ -1,0 +1,11 @@
+within LieGroups.SO3.Quat;
+function product "Hamilton quaternion product q * p"
+  input Real q[4] "Left quaternion {w,x,y,z}";
+  input Real p[4] "Right quaternion {w,x,y,z}";
+  output Real r[4] "Result quaternion {w,x,y,z}";
+algorithm
+  r[1] := q[1]*p[1] - q[2]*p[2] - q[3]*p[3] - q[4]*p[4];
+  r[2] := q[2]*p[1] + q[1]*p[2] - q[4]*p[3] + q[3]*p[4];
+  r[3] := q[3]*p[1] + q[4]*p[2] + q[1]*p[3] - q[2]*p[4];
+  r[4] := q[4]*p[1] - q[3]*p[2] + q[2]*p[3] + q[1]*p[4];
+end product;

--- a/LieGroups/SO3/Quat/right_jacobian.mo
+++ b/LieGroups/SO3/Quat/right_jacobian.mo
@@ -1,0 +1,44 @@
+within LieGroups.SO3.Quat;
+function right_jacobian "Right Jacobian J_r(v) of SO(3)"
+  input Real v[3] "Rotation vector";
+  output Real J[3,3] "3x3 right Jacobian matrix";
+protected
+  Real theta_sq;
+  Real A "(1 - cos(theta)) / theta^2";
+  Real B "(theta - sin(theta)) / theta^3";
+  Real theta;
+  Real S[3,3] "Skew-symmetric [v]x";
+  Real S2[3,3] "[v]x * [v]x";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  S := {{0, -v[3], v[2]},
+        {v[3], 0, -v[1]},
+        {-v[2], v[1], 0}};
+
+  S2 := {{-(v[2]^2 + v[3]^2), v[1]*v[2], v[1]*v[3]},
+         {v[1]*v[2], -(v[1]^2 + v[3]^2), v[2]*v[3]},
+         {v[1]*v[3], v[2]*v[3], -(v[1]^2 + v[2]^2)}};
+
+  if theta_sq < eps then
+    A := 0.5 - theta_sq / 24.0;
+    B := 1.0/6.0 - theta_sq / 120.0;
+  else
+    theta := sqrt(theta_sq);
+    A := (1.0 - cos(theta)) / theta_sq;
+    B := (theta - sin(theta)) / (theta_sq * theta);
+  end if;
+
+  // J_r = I - A * [v]x + B * [v]x^2  (note: minus sign on A term vs left Jacobian)
+  for i in 1:3 loop
+    for j in 1:3 loop
+      J[i,j] := (if i == j then 1.0 else 0.0) - A * S[i,j] + B * S2[i,j];
+    end for;
+  end for;
+
+  annotation(Documentation(info="<html>
+    <p>Right Jacobian of SO(3): J_r(v) = I - ((1-cos θ)/θ²)[v]× + ((θ-sin θ)/θ³)[v]×²</p>
+    <p>Related to left Jacobian by: J_r(v) = J_l(-v)</p>
+  </html>"));
+end right_jacobian;

--- a/LieGroups/SO3/Quat/right_jacobian_inv.mo
+++ b/LieGroups/SO3/Quat/right_jacobian_inv.mo
@@ -1,0 +1,41 @@
+within LieGroups.SO3.Quat;
+function right_jacobian_inv "Inverse right Jacobian J_r^{-1}(v) of SO(3)"
+  input Real v[3] "Rotation vector";
+  output Real J_inv[3,3] "3x3 inverse right Jacobian matrix";
+protected
+  Real theta_sq;
+  Real C "1/theta^2 + sin(theta)/(2*theta*(cos(theta)-1))";
+  Real theta;
+  Real S[3,3] "Skew-symmetric [v]x";
+  Real S2[3,3] "[v]x * [v]x";
+  constant Real eps = 1e-8;
+algorithm
+  theta_sq := v[1]^2 + v[2]^2 + v[3]^2;
+
+  S := {{0, -v[3], v[2]},
+        {v[3], 0, -v[1]},
+        {-v[2], v[1], 0}};
+
+  S2 := {{-(v[2]^2 + v[3]^2), v[1]*v[2], v[1]*v[3]},
+         {v[1]*v[2], -(v[1]^2 + v[3]^2), v[2]*v[3]},
+         {v[1]*v[3], v[2]*v[3], -(v[1]^2 + v[2]^2)}};
+
+  if theta_sq < eps then
+    C := 1.0/12.0 + theta_sq / 720.0;
+  else
+    theta := sqrt(theta_sq);
+    C := 1.0 / theta_sq + sin(theta) / (2.0 * theta * (cos(theta) - 1.0));
+  end if;
+
+  // J_r^{-1} = I + 0.5 * [v]x + C * [v]x^2  (note: plus sign on 0.5 term vs left inv)
+  for i in 1:3 loop
+    for j in 1:3 loop
+      J_inv[i,j] := (if i == j then 1.0 else 0.0) + 0.5 * S[i,j] + C * S2[i,j];
+    end for;
+  end for;
+
+  annotation(Documentation(info="<html>
+    <p>Inverse right Jacobian of SO(3): J_r^{-1}(v) = I + ½[v]× + C·[v]×²</p>
+    <p>Related to inverse left Jacobian by: J_r^{-1}(v) = J_l^{-1}(-v)</p>
+  </html>"));
+end right_jacobian_inv;

--- a/LieGroups/SO3/Quat/rotate.mo
+++ b/LieGroups/SO3/Quat/rotate.mo
@@ -1,0 +1,13 @@
+within LieGroups.SO3.Quat;
+function rotate "Rotate a 3-vector by a quaternion: v' = q @ v"
+  input Real q[4] "Unit quaternion {w,x,y,z}";
+  input Real v[3] "Input vector";
+  output Real v_out[3] "Rotated vector";
+protected
+  Real R[3,3];
+algorithm
+  R := LieGroups.SO3.Quat.to_DCM(q);
+  v_out[1] := R[1,1]*v[1] + R[1,2]*v[2] + R[1,3]*v[3];
+  v_out[2] := R[2,1]*v[1] + R[2,2]*v[2] + R[2,3]*v[3];
+  v_out[3] := R[3,1]*v[1] + R[3,2]*v[2] + R[3,3]*v[3];
+end rotate;

--- a/LieGroups/SO3/Quat/small_adjoint.mo
+++ b/LieGroups/SO3/Quat/small_adjoint.mo
@@ -1,0 +1,14 @@
+within LieGroups.SO3.Quat;
+function small_adjoint "Small adjoint ad_xi: the 3x3 skew-symmetric matrix [v]x"
+  input Real v[3] "Lie algebra element (rotation vector)";
+  output Real ad[3,3] "3x3 skew-symmetric matrix";
+algorithm
+  ad[1,1] :=  0;     ad[1,2] := -v[3];  ad[1,3] :=  v[2];
+  ad[2,1] :=  v[3];  ad[2,2] :=  0;     ad[2,3] := -v[1];
+  ad[3,1] := -v[2];  ad[3,2] :=  v[1];  ad[3,3] :=  0;
+  annotation(Documentation(info="<html>
+    <p>The small adjoint ad_xi for so(3) is the skew-symmetric (hat/wedge) matrix:
+    ad_v(w) = v x w (cross product). [xi_1, xi_2] = ad_{xi_1} xi_2.</p>
+    <p>Used in continuous-time IEKF: A_c = -ad_{xi_hat}</p>
+  </html>"));
+end small_adjoint;

--- a/LieGroups/SO3/Quat/to_DCM.mo
+++ b/LieGroups/SO3/Quat/to_DCM.mo
@@ -1,0 +1,24 @@
+within LieGroups.SO3.Quat;
+function to_DCM "Convert unit quaternion to 3x3 rotation matrix (DCM)"
+  input Real q[4] "{w,x,y,z}";
+  output Real R[3,3] "Rotation matrix (body to world)";
+protected
+  Real a, b, c, d;
+  Real aa, ab, ac, ad, bb, bc, bd, cc, cd, dd;
+algorithm
+  a := q[1]; b := q[2]; c := q[3]; d := q[4];
+  aa := a*a; ab := a*b; ac := a*c; ad := a*d;
+  bb := b*b; bc := b*c; bd := b*d;
+  cc := c*c; cd := c*d;
+  dd := d*d;
+
+  R[1,1] := aa + bb - cc - dd;
+  R[1,2] := 2*(bc - ad);
+  R[1,3] := 2*(bd + ac);
+  R[2,1] := 2*(bc + ad);
+  R[2,2] := aa - bb + cc - dd;
+  R[2,3] := 2*(cd - ab);
+  R[3,1] := 2*(bd - ac);
+  R[3,2] := 2*(cd + ab);
+  R[3,3] := aa - bb - cc + dd;
+end to_DCM;

--- a/LieGroups/SO3/Quat/vee.mo
+++ b/LieGroups/SO3/Quat/vee.mo
@@ -1,0 +1,9 @@
+within LieGroups.SO3.Quat;
+function vee "Vee map: 3x3 skew-symmetric matrix -> so(3) vector (S^vee)"
+  input Real S[3,3] "Skew-symmetric matrix";
+  output Real v[3] "Rotation vector";
+algorithm
+  v[1] := S[3,2];
+  v[2] := S[1,3];
+  v[3] := S[2,1];
+end vee;

--- a/LieGroups/SO3/Quat/wedge.mo
+++ b/LieGroups/SO3/Quat/wedge.mo
@@ -1,0 +1,9 @@
+within LieGroups.SO3.Quat;
+function wedge "Wedge map: so(3) vector -> 3x3 skew-symmetric matrix (xi^wedge)"
+  input Real v[3] "Rotation vector";
+  output Real S[3,3] "Skew-symmetric matrix [v]x";
+algorithm
+  S[1,1] :=  0;     S[1,2] := -v[3];  S[1,3] :=  v[2];
+  S[2,1] :=  v[3];  S[2,2] :=  0;     S[2,3] := -v[1];
+  S[3,1] := -v[2];  S[3,2] :=  v[1];  S[3,3] :=  0;
+end wedge;

--- a/LieGroups/SO3/package.mo
+++ b/LieGroups/SO3/package.mo
@@ -1,0 +1,3 @@
+within LieGroups;
+package SO3 "Special Orthogonal Group SO(3) — 3D rotations"
+end SO3;

--- a/LieGroups/Util/angle_wrap.mo
+++ b/LieGroups/Util/angle_wrap.mo
@@ -1,0 +1,9 @@
+within LieGroups.Util;
+function angle_wrap "Wrap angle to [-pi, pi]"
+  input Real theta;
+  output Real wrapped;
+protected
+  constant Real pi = 3.1415926535897932384626433832795;
+algorithm
+  wrapped := theta - 2*pi * floor((theta + pi) / (2*pi));
+end angle_wrap;

--- a/LieGroups/Util/package.mo
+++ b/LieGroups/Util/package.mo
@@ -1,0 +1,3 @@
+within LieGroups;
+package Util "Utility functions"
+end Util;

--- a/LieGroups/Util/saturate.mo
+++ b/LieGroups/Util/saturate.mo
@@ -1,0 +1,9 @@
+within LieGroups.Util;
+function saturate "Clamp scalar to [x_min, x_max]"
+  input Real x;
+  input Real x_min;
+  input Real x_max;
+  output Real y;
+algorithm
+  y := if x > x_max then x_max elseif x < x_min then x_min else x;
+end saturate;

--- a/LieGroups/Util/saturate3.mo
+++ b/LieGroups/Util/saturate3.mo
@@ -1,0 +1,13 @@
+within LieGroups.Util;
+function saturate3 "Clamp 3-vector element-wise"
+  input Real x[3];
+  input Real x_min[3];
+  input Real x_max[3];
+  output Real y[3];
+algorithm
+  for i in 1:3 loop
+    y[i] := if x[i] > x_max[i] then x_max[i]
+            elseif x[i] < x_min[i] then x_min[i]
+            else x[i];
+  end for;
+end saturate3;

--- a/LieGroups/package.mo
+++ b/LieGroups/package.mo
@@ -1,0 +1,7 @@
+within;
+package LieGroups "Lie group library for rigid body mechanics"
+  annotation(Documentation(info="<html>
+    <p>Modelica implementation of Lie group operations for SO(3) and related groups.</p>
+    <p>Quaternion convention: q = {w, x, y, z} (scalar first, Hamilton).</p>
+  </html>"));
+end LieGroups;

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Reusable Modelica building blocks for FastDyn/Rumoca simulations.
 
 - `LieGroup/`: lightweight SO(3) and quaternion utilities used by the
   generic rigid-body templates.
+- `LieGroups/`: full Lie group library (SO(2)/SO(3), SE(2)/SE(3)/SE_2(3),
+  with quaternion, DCM, MRP, and Euler-B321 SO(3) charts) providing exp/log
+  maps, products, adjoints, and left/right Jacobians.
 - `Geodesy/`: reusable local-frame and geodetic conversion helpers.
 - `RigidBody/`: reusable six-degree-of-freedom rigid-body dynamics.
 - `RigidBody/Examples/`: reusable base plants for quadrotor, rover, and


### PR DESCRIPTION
Adds the full Lie group library (`package LieGroups`) alongside the existing
lightweight `LieGroup` SO(3) helper.

## What's included
- **`LieGroups/`** — SO(2)/SO(3), SE(2)/SE(3), and SE_2(3) groups with multiple
  SO(3) charts (quaternion, DCM, MRP, Euler-B321): exp/log maps, products,
  inverses, adjoints, and left/right Jacobians (82 `.mo` files).
- **`release.yml`** — include `LieGroups` in the CMM release archive and notes
  (the packaging step lists directories explicitly, so a new package must be
  added here or it is silently omitted from the zip).
- **`README.md`** — document the new package.
