### PR TITLE
Make mocap IEKF packet discrete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,10 @@ jobs:
       - name: Run tests
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
-          MOCAP_IEKF_ARTIFACT_DIR: test_artifacts/mocap_iekf
         run: |
-          nix $NIX_FLAGS develop github:CogniPilot/rumoca --command bash -lc '
+          nix $NIX_FLAGS develop .#ci --command bash -lc '
             set -euo pipefail
             python -m venv "$RUNNER_TEMP/modelica-models-ci"
             "$RUNNER_TEMP/modelica-models-ci/bin/python" -m pip install --upgrade pip pytest rumoca
             "$RUNNER_TEMP/modelica-models-ci/bin/python" -m pytest -q
           '
-      - name: Upload mocap IEKF artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: mocap-iekf-regression
-          path: test_artifacts/mocap_iekf
-          if-no-files-found: warn

--- a/Estimation/Examples/MocapExternalOdometryIEKF.mo
+++ b/Estimation/Examples/MocapExternalOdometryIEKF.mo
@@ -1,19 +1,12 @@
 within Estimation.Examples;
 
-// Fixed-step SE_2(3) prediction model for a 12D invariant/error-state EKF used
-// to turn intermittent motion-capture poses into external odometry.
-//
-// Nominal state:
-//   attitude_wxyz              world-to-body attitude quaternion
-//   linear_velocity_enu_m_s    world-frame linear velocity
-//   position_enu_m             world-frame position
-//   angular_velocity_flu_rad_s body-frame angular velocity
-//
-// Tangent covariance order:
-//   attitude error, linear velocity, position, angular velocity.
-//
-// Discrete pose correction, gating, dropout policy, covariance stabilization,
-// and transport-specific scheduling are intentionally outside this model.
+// Packet-driven discrete wrapper for the mocap IEKF step used by
+// synapse_qualisys_bridge. The flat state layout is:
+//   1:4     attitude_wxyz
+//   5:7     linear_velocity_enu_m_s
+//   8:10    position_enu_m
+//   11:13   angular_velocity_flu_rad_s
+//   14:157  12x12 tangent covariance, column-major
 
 model MocapExternalOdometryIEKF
   parameter Real attitudeProcessVariance = 1.0e-6
@@ -24,207 +17,53 @@ model MocapExternalOdometryIEKF
     "position random-walk spectral density [m2/s]";
   parameter Real angularVelocityProcessVariance = 1.0e-4
     "angular velocity random-walk spectral density [(rad/s)2/s]";
-  constant Real predictionStep_s = 1.0 / 240.0
-    "Fixed prediction step used by the SE_2(3) mixed exponential [s]";
+  parameter Real attitudeMeasurementVariance = 0.010^2
+    "attitude measurement variance [rad2]";
+  parameter Real positionMeasurementVariance = 0.004^2
+    "position measurement variance [m2]";
 
-  Real attitude_wxyz[4](start = {1.0, 0.0, 0.0, 0.0})
-    "world-to-body attitude quaternion as w,x,y,z";
-  Real linear_velocity_enu_m_s[3](start = {0.0, 0.0, 0.0})
-    "World-frame linear velocity [m/s]";
-  Real position_enu_m[3](start = {0.0, 0.0, 0.0})
-    "World-frame position [m]";
-  Real angular_velocity_flu_rad_s[3](start = {0.0, 0.0, 0.0})
-    "Body-frame angular velocity [rad/s]";
-  Real covariance[12, 12](start = identity(12))
-    "12D tangent covariance: attitude, velocity, position, angular velocity";
+  input Real x_prev[157](start = zeros(157))
+    "Previous flat IEKF state";
+  input Real dt_s(start = 1.0 / 240.0)
+    "Packet interval since the previous estimator update [s]";
+  input Real measurement_valid(start = 1.0)
+    "Greater than 0.5 when measurement_position_enu_m and measurement_attitude_wxyz are valid";
+  input Real measurement_position_enu_m[3](start = {0.0, 0.0, 0.0})
+    "Measured position [m]";
+  input Real measurement_attitude_wxyz[4](start = {1.0, 0.0, 0.0, 0.0})
+    "Measured attitude quaternion";
+
+  output Real x_next[157]
+    "Next flat IEKF state after prediction and optional correction";
+  output Real correction_accepted
+    "1 when a requested correction succeeded, 0 when skipped or singular";
 
 equation
-  der(position_enu_m[1]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[1] - position_enu_m[1]) / predictionStep_s;
-  der(position_enu_m[2]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[2] - position_enu_m[2]) / predictionStep_s;
-  der(position_enu_m[3]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[3] - position_enu_m[3]) / predictionStep_s;
-  der(linear_velocity_enu_m_s[1]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[4] - linear_velocity_enu_m_s[1]) / predictionStep_s;
-  der(linear_velocity_enu_m_s[2]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[5] - linear_velocity_enu_m_s[2]) / predictionStep_s;
-  der(linear_velocity_enu_m_s[3]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[6] - linear_velocity_enu_m_s[3]) / predictionStep_s;
-  der(attitude_wxyz[1]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[7] - attitude_wxyz[1]) / predictionStep_s;
-  der(attitude_wxyz[2]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[8] - attitude_wxyz[2]) / predictionStep_s;
-  der(attitude_wxyz[3]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[9] - attitude_wxyz[3]) / predictionStep_s;
-  der(attitude_wxyz[4]) = (
-    LieGroups.SE23.Quat.exp_mixed(
-      {position_enu_m[1], position_enu_m[2], position_enu_m[3],
-       linear_velocity_enu_m_s[1], linear_velocity_enu_m_s[2], linear_velocity_enu_m_s[3],
-       attitude_wxyz[1], attitude_wxyz[2], attitude_wxyz[3], attitude_wxyz[4]},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-       angular_velocity_flu_rad_s[1] * predictionStep_s,
-       angular_velocity_flu_rad_s[2] * predictionStep_s,
-       angular_velocity_flu_rad_s[3] * predictionStep_s},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      [0.0, predictionStep_s; 0.0, 0.0])[10] - attitude_wxyz[4]) / predictionStep_s;
-  der(angular_velocity_flu_rad_s) = {0.0, 0.0, 0.0};
+  (x_next, correction_accepted) = Estimation.MocapExternalOdometryIEKF.step(
+    x_prev,
+    dt_s,
+    measurement_valid,
+    measurement_position_enu_m,
+    measurement_attitude_wxyz,
+    {
+      attitudeProcessVariance,
+      velocityProcessVariance,
+      positionProcessVariance,
+      angularVelocityProcessVariance},
+    attitudeMeasurementVariance,
+    positionMeasurementVariance);
 
-  for i in 1:3 loop
-    for j in 1:3 loop
-      der(covariance[i, j]) =
-        covariance[i + 9, j] + covariance[i, j + 9];
-    end for;
-    for j in 4:6 loop
-      der(covariance[i, j]) = covariance[i + 9, j];
-    end for;
-    for j in 7:9 loop
-      der(covariance[i, j]) = covariance[i + 9, j] + covariance[i, j - 3];
-    end for;
-    for j in 10:12 loop
-      der(covariance[i, j]) = covariance[i + 9, j];
-    end for;
-  end for;
-
-  for i in 4:6 loop
-    for j in 1:3 loop
-      der(covariance[i, j]) = covariance[i, j + 9];
-    end for;
-    for j in 4:6 loop
-      der(covariance[i, j]) = 0.0;
-    end for;
-    for j in 7:9 loop
-      der(covariance[i, j]) = covariance[i, j - 3];
-    end for;
-    for j in 10:12 loop
-      der(covariance[i, j]) = 0.0;
-    end for;
-  end for;
-
-  for i in 7:9 loop
-    for j in 1:3 loop
-      der(covariance[i, j]) = covariance[i - 3, j] + covariance[i, j + 9];
-    end for;
-    for j in 4:6 loop
-      der(covariance[i, j]) = covariance[i - 3, j];
-    end for;
-    for j in 7:9 loop
-      der(covariance[i, j]) =
-        covariance[i - 3, j] + covariance[i, j - 3];
-    end for;
-    for j in 10:12 loop
-      der(covariance[i, j]) = covariance[i - 3, j];
-    end for;
-  end for;
-
-  for i in 10:12 loop
-    for j in 1:3 loop
-      der(covariance[i, j]) = covariance[i, j + 9];
-    end for;
-    for j in 4:6 loop
-      der(covariance[i, j]) = 0.0;
-    end for;
-    for j in 7:9 loop
-      der(covariance[i, j]) = covariance[i, j - 3];
-    end for;
-    for j in 10:12 loop
-      der(covariance[i, j]) = 0.0;
-    end for;
-  end for;
   annotation(Documentation(info="<html>
     <p>
-      The nominal pose/velocity prediction uses the closed-form mixed
-      exponential on SE_2(3), following Lin, Li-Yu, et al.,
-      &quot;On Closed-Form Preintegration for a Class of Mixed-Invariant Systems
-      in SEn(3),&quot; IEEE Control Systems Letters, 2025.
+      This is a discrete packet update, not a continuous ODE model. It is
+      intended for bridges that call the estimator once per mocap packet with
+      the previous flat state and the packet interval.
     </p>
     <p>
-      Callers provide <code>l * dt</code>, <code>r * dt</code>, and
-      <code>B * dt</code> to the mixed exponential. For pose-only mocap
-      prediction the left increment
-      carries the estimated body angular velocity, the right increment is zero,
-      and <code>B = {{0, 1}, {0, 0}}</code> advances position from velocity.
+      The prediction uses the closed-form mixed exponential on SE_2(3),
+      following Lin, Li-Yu, et al.,
+      &quot;On Closed-Form Preintegration for a Class of Mixed-Invariant Systems
+      in SEn(3),&quot; IEEE Control Systems Letters, 2025.
     </p>
   </html>"));
 end MocapExternalOdometryIEKF;

--- a/Estimation/MocapExternalOdometryIEKF/correct.mo
+++ b/Estimation/MocapExternalOdometryIEKF/correct.mo
@@ -1,0 +1,113 @@
+within Estimation.MocapExternalOdometryIEKF;
+function correct "Discrete pose correction for the mocap IEKF"
+  input Real x_pred[157] "Predicted flat state";
+  input Real measurement_position_enu_m[3] "Measured position [m]";
+  input Real measurement_attitude_wxyz[4] "Measured attitude quaternion";
+  input Real attitudeMeasurementVariance "Attitude measurement variance [rad2]";
+  input Real positionMeasurementVariance "Position measurement variance [m2]";
+  output Real x_next[157] "Corrected flat state";
+  output Real accepted "1 when correction succeeded, otherwise 0";
+protected
+  Integer observed[6] = {1, 2, 3, 7, 8, 9};
+  Real state_pred[13];
+  Real state_next[13];
+  Real covariance_pred[12, 12];
+  Real covariance_next[12, 12];
+  Real residual[6];
+  Real attitude_residual[3];
+  Real dq[4];
+  Real innovation_covariance[6, 6];
+  Real innovation_covariance_inv[6, 6];
+  Real inverse_ok;
+  Real gain[12, 6];
+  Real correction[12];
+  Real a[12, 12];
+  Real measurement_noise[6, 6];
+algorithm
+  state_pred := x_pred[1:13];
+  for row in 1:12 loop
+    for col in 1:12 loop
+      covariance_pred[row, col] := x_pred[13 + (col - 1) * 12 + row];
+    end for;
+  end for;
+
+  dq := LieGroups.SO3.Quat.product(
+    LieGroups.SO3.Quat.inverse(state_pred[1:4]),
+    LieGroups.SO3.Quat.normalize(measurement_attitude_wxyz));
+  attitude_residual := LieGroups.SO3.Quat.log_map(dq);
+  for i in 1:3 loop
+    residual[i] := attitude_residual[i];
+    residual[i + 3] := measurement_position_enu_m[i] - state_pred[i + 7];
+  end for;
+
+  for row in 1:6 loop
+    for col in 1:6 loop
+      innovation_covariance[row, col] :=
+        covariance_pred[observed[row], observed[col]];
+      measurement_noise[row, col] := 0.0;
+    end for;
+  end for;
+  for i in 1:3 loop
+    innovation_covariance[i, i] :=
+      innovation_covariance[i, i] + attitudeMeasurementVariance;
+    innovation_covariance[i + 3, i + 3] :=
+      innovation_covariance[i + 3, i + 3] + positionMeasurementVariance;
+    measurement_noise[i, i] := attitudeMeasurementVariance;
+    measurement_noise[i + 3, i + 3] := positionMeasurementVariance;
+  end for;
+
+  (innovation_covariance_inv, inverse_ok) :=
+    Estimation.MocapExternalOdometryIEKF.inverse6(innovation_covariance);
+  if inverse_ok < 0.5 then
+    x_next := x_pred;
+    accepted := 0.0;
+  else
+    for row in 1:12 loop
+      for meas in 1:6 loop
+        gain[row, meas] := 0.0;
+        for k in 1:6 loop
+          gain[row, meas] := gain[row, meas]
+            + covariance_pred[row, observed[k]]
+            * innovation_covariance_inv[k, meas];
+        end for;
+      end for;
+    end for;
+
+    for row in 1:12 loop
+      correction[row] := 0.0;
+      for meas in 1:6 loop
+        correction[row] := correction[row] + gain[row, meas] * residual[meas];
+      end for;
+    end for;
+
+    state_next :=
+      Estimation.MocapExternalOdometryIEKF.inject(state_pred, correction);
+
+    a := identity(12);
+    for row in 1:12 loop
+      a[row, 1] := a[row, 1] - gain[row, 1];
+      a[row, 2] := a[row, 2] - gain[row, 2];
+      a[row, 3] := a[row, 3] - gain[row, 3];
+      a[row, 7] := a[row, 7] - gain[row, 4];
+      a[row, 8] := a[row, 8] - gain[row, 5];
+      a[row, 9] := a[row, 9] - gain[row, 6];
+    end for;
+    covariance_next := Estimation.MocapExternalOdometryIEKF.joseph_update(
+      a,
+      covariance_pred,
+      gain,
+      measurement_noise);
+    covariance_next :=
+      Estimation.MocapExternalOdometryIEKF.stabilize_covariance(covariance_next);
+
+    for i in 1:13 loop
+      x_next[i] := state_next[i];
+    end for;
+    for row in 1:12 loop
+      for col in 1:12 loop
+        x_next[13 + (col - 1) * 12 + row] := covariance_next[row, col];
+      end for;
+    end for;
+    accepted := 1.0;
+  end if;
+end correct;

--- a/Estimation/MocapExternalOdometryIEKF/initialize.mo
+++ b/Estimation/MocapExternalOdometryIEKF/initialize.mo
@@ -1,0 +1,26 @@
+within Estimation.MocapExternalOdometryIEKF;
+function initialize "Initialize flat IEKF state from a pose measurement"
+  input Real position_enu_m[3];
+  input Real attitude_wxyz[4];
+  input Real attitudeVariance;
+  input Real velocityVariance;
+  input Real positionVariance;
+  input Real angularVelocityVariance;
+  output Real x[157]
+    "Flat state: attitude, velocity, position, angular velocity, covariance";
+protected
+  Real attitude[4];
+algorithm
+  x := zeros(157);
+  attitude := LieGroups.SO3.Quat.normalize(attitude_wxyz);
+  for i in 1:4 loop
+    x[i] := attitude[i];
+  end for;
+  for i in 1:3 loop
+    x[i + 7] := position_enu_m[i];
+    x[13 + (i - 1) * 12 + i] := attitudeVariance;
+    x[13 + (i + 2) * 12 + i + 3] := velocityVariance;
+    x[13 + (i + 5) * 12 + i + 6] := positionVariance;
+    x[13 + (i + 8) * 12 + i + 9] := angularVelocityVariance;
+  end for;
+end initialize;

--- a/Estimation/MocapExternalOdometryIEKF/inject.mo
+++ b/Estimation/MocapExternalOdometryIEKF/inject.mo
@@ -1,0 +1,24 @@
+within Estimation.MocapExternalOdometryIEKF;
+function inject "Inject a 12D tangent correction into the 13D nominal state"
+  input Real state[13] "{attitude, velocity, position, angular velocity}";
+  input Real correction[12]
+    "{attitude error, velocity error, position error, angular velocity error}";
+  output Real state_next[13];
+protected
+  Real attitude_delta[4];
+  Real attitude_next[4];
+algorithm
+  attitude_delta := LieGroups.SO3.Quat.exp_map(correction[1:3]);
+  attitude_next :=
+    LieGroups.SO3.Quat.product(state[1:4], attitude_delta);
+  attitude_next := LieGroups.SO3.Quat.normalize(attitude_next);
+
+  for i in 1:4 loop
+    state_next[i] := attitude_next[i];
+  end for;
+  for i in 1:3 loop
+    state_next[i + 4] := state[i + 4] + correction[i + 3];
+    state_next[i + 7] := state[i + 7] + correction[i + 6];
+    state_next[i + 10] := state[i + 10] + correction[i + 9];
+  end for;
+end inject;

--- a/Estimation/MocapExternalOdometryIEKF/inverse6.mo
+++ b/Estimation/MocapExternalOdometryIEKF/inverse6.mo
@@ -1,0 +1,40 @@
+within Estimation.MocapExternalOdometryIEKF;
+function inverse6 "Gauss-Jordan inverse for a 6x6 matrix"
+  input Real matrix[6, 6];
+  output Real matrix_inv[6, 6];
+  output Real ok "1 when inversion succeeded, 0 when singular";
+protected
+  Real a[6, 6];
+  Real diag;
+  Real factor;
+algorithm
+  a := matrix;
+  matrix_inv := identity(6);
+  ok := 1.0;
+
+  for pivot in 1:6 loop
+    if ok > 0.5 then
+      diag := a[pivot, pivot];
+      if abs(diag) < 1.0e-18 then
+        matrix_inv := identity(6);
+        ok := 0.0;
+      else
+        for col in 1:6 loop
+          a[pivot, col] := a[pivot, col] / diag;
+          matrix_inv[pivot, col] := matrix_inv[pivot, col] / diag;
+        end for;
+
+        for row in 1:6 loop
+          if row <> pivot then
+            factor := a[row, pivot];
+            for col in 1:6 loop
+              a[row, col] := a[row, col] - factor * a[pivot, col];
+              matrix_inv[row, col] :=
+                matrix_inv[row, col] - factor * matrix_inv[pivot, col];
+            end for;
+          end if;
+        end for;
+      end if;
+    end if;
+  end for;
+end inverse6;

--- a/Estimation/MocapExternalOdometryIEKF/joseph_update.mo
+++ b/Estimation/MocapExternalOdometryIEKF/joseph_update.mo
@@ -1,0 +1,16 @@
+within Estimation.MocapExternalOdometryIEKF;
+function joseph_update "Joseph-form covariance correction"
+  input Real a[12, 12] "I - K H";
+  input Real covariance[12, 12] "Predicted covariance";
+  input Real gain[12, 6] "Kalman gain";
+  input Real measurement_noise[6, 6] "Measurement covariance";
+  output Real covariance_next[12, 12];
+protected
+  Real ap[12, 12];
+  Real kr[12, 6];
+algorithm
+  ap := a * covariance;
+  covariance_next := ap * transpose(a);
+  kr := gain * measurement_noise;
+  covariance_next := covariance_next + kr * transpose(gain);
+end joseph_update;

--- a/Estimation/MocapExternalOdometryIEKF/package.mo
+++ b/Estimation/MocapExternalOdometryIEKF/package.mo
@@ -1,0 +1,7 @@
+within Estimation;
+package MocapExternalOdometryIEKF
+  constant Integer StateLength = 157
+    "Flat state length: attitude, velocity, position, angular velocity, covariance";
+  constant Integer TangentLength = 12
+    "Tangent covariance dimension";
+end MocapExternalOdometryIEKF;

--- a/Estimation/MocapExternalOdometryIEKF/package.order
+++ b/Estimation/MocapExternalOdometryIEKF/package.order
@@ -1,0 +1,8 @@
+stabilize_covariance
+inverse6
+joseph_update
+inject
+initialize
+predict
+correct
+step

--- a/Estimation/MocapExternalOdometryIEKF/predict.mo
+++ b/Estimation/MocapExternalOdometryIEKF/predict.mo
@@ -1,0 +1,88 @@
+within Estimation.MocapExternalOdometryIEKF;
+function predict "Discrete SE_2(3) prediction for one mocap IEKF step"
+  input Real x_prev[157]
+    "Flat state: attitude, velocity, position, angular velocity, covariance";
+  input Real dt_s "Prediction interval [s]";
+  input Real process_variance[4]
+    "{attitude, velocity, position, angular velocity} spectral densities";
+  output Real x_pred[157] "Predicted flat state";
+protected
+  Real state_prev[13];
+  Real state_pred[13];
+  Real covariance_prev[12, 12];
+  Real covariance_pred[12, 12];
+  Real transition[12, 12];
+  Real transition_covariance[12, 12];
+  Real se23_state[10];
+  Real se23_prediction[10];
+  Real attitude_pred[4];
+  Real left_increment[9];
+  Real zero_increment[9];
+  Real coupling[2, 2];
+algorithm
+  state_prev := x_prev[1:13];
+  for row in 1:12 loop
+    for col in 1:12 loop
+      covariance_prev[row, col] := x_prev[13 + (col - 1) * 12 + row];
+    end for;
+  end for;
+
+  se23_state := {
+    state_prev[8], state_prev[9], state_prev[10],
+    state_prev[5], state_prev[6], state_prev[7],
+    state_prev[1], state_prev[2], state_prev[3], state_prev[4]};
+  left_increment := {
+    0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0,
+    state_prev[11] * dt_s,
+    state_prev[12] * dt_s,
+    state_prev[13] * dt_s};
+  zero_increment := zeros(9);
+  coupling := [0.0, dt_s; 0.0, 0.0];
+
+  se23_prediction := LieGroups.SE23.Quat.exp_mixed(
+    se23_state,
+    left_increment,
+    zero_increment,
+    coupling);
+
+  attitude_pred :=
+    LieGroups.SO3.Quat.normalize(se23_prediction[7:10]);
+  for i in 1:4 loop
+    state_pred[i] := attitude_pred[i];
+  end for;
+  for i in 1:3 loop
+    state_pred[i + 4] := se23_prediction[i + 3];
+    state_pred[i + 7] := se23_prediction[i];
+    state_pred[i + 10] := state_prev[i + 10];
+  end for;
+
+  transition := identity(12);
+  for axis in 1:3 loop
+    transition[axis, axis + 9] := dt_s;
+    transition[axis + 6, axis + 3] := dt_s;
+  end for;
+  transition_covariance := transition * covariance_prev;
+  covariance_pred := transition_covariance * transpose(transition);
+  for axis in 1:3 loop
+    covariance_pred[axis, axis] :=
+      covariance_pred[axis, axis] + process_variance[1] * dt_s;
+    covariance_pred[axis + 3, axis + 3] :=
+      covariance_pred[axis + 3, axis + 3] + process_variance[2] * dt_s;
+    covariance_pred[axis + 6, axis + 6] :=
+      covariance_pred[axis + 6, axis + 6] + process_variance[3] * dt_s;
+    covariance_pred[axis + 9, axis + 9] :=
+      covariance_pred[axis + 9, axis + 9] + process_variance[4] * dt_s;
+  end for;
+  covariance_pred :=
+    Estimation.MocapExternalOdometryIEKF.stabilize_covariance(covariance_pred);
+
+  for i in 1:13 loop
+    x_pred[i] := state_pred[i];
+  end for;
+  for row in 1:12 loop
+    for col in 1:12 loop
+      x_pred[13 + (col - 1) * 12 + row] := covariance_pred[row, col];
+    end for;
+  end for;
+end predict;

--- a/Estimation/MocapExternalOdometryIEKF/stabilize_covariance.mo
+++ b/Estimation/MocapExternalOdometryIEKF/stabilize_covariance.mo
@@ -1,0 +1,18 @@
+within Estimation.MocapExternalOdometryIEKF;
+function stabilize_covariance "Symmetrize covariance and floor diagonal variances"
+  input Real covariance[12, 12];
+  output Real stabilized[12, 12];
+protected
+  Real value;
+  constant Real minVariance = 1.0e-12;
+algorithm
+  stabilized := covariance;
+  for row in 1:12 loop
+    for col in row + 1:12 loop
+      value := 0.5 * (stabilized[row, col] + stabilized[col, row]);
+      stabilized[row, col] := value;
+      stabilized[col, row] := value;
+    end for;
+    stabilized[row, row] := max(stabilized[row, row], minVariance);
+  end for;
+end stabilize_covariance;

--- a/Estimation/MocapExternalOdometryIEKF/step.mo
+++ b/Estimation/MocapExternalOdometryIEKF/step.mo
@@ -1,0 +1,36 @@
+within Estimation.MocapExternalOdometryIEKF;
+function step "One packet-driven discrete mocap IEKF step"
+  input Real x_prev[157]
+    "Flat state before this packet: attitude, velocity, position, angular velocity, covariance";
+  input Real dt_s "Prediction interval from previous packet [s]";
+  input Real measurement_valid
+    "Greater than 0.5 when the pose measurement should be corrected";
+  input Real measurement_position_enu_m[3] "Measured position [m]";
+  input Real measurement_attitude_wxyz[4] "Measured attitude quaternion";
+  input Real process_variance[4]
+    "{attitude, velocity, position, angular velocity} spectral densities";
+  input Real attitudeMeasurementVariance "Attitude measurement variance [rad2]";
+  input Real positionMeasurementVariance "Position measurement variance [m2]";
+  output Real x_next[157] "Flat state after prediction and optional correction";
+  output Real correction_accepted
+    "1 when a requested correction succeeded, 0 when skipped or singular";
+protected
+  Real x_pred[157];
+algorithm
+  x_pred := Estimation.MocapExternalOdometryIEKF.predict(
+    x_prev,
+    dt_s,
+    process_variance);
+
+  if measurement_valid > 0.5 then
+    (x_next, correction_accepted) := Estimation.MocapExternalOdometryIEKF.correct(
+      x_pred,
+      measurement_position_enu_m,
+      measurement_attitude_wxyz,
+      attitudeMeasurementVariance,
+      positionMeasurementVariance);
+  else
+    x_next := x_pred;
+    correction_accepted := 0.0;
+  end if;
+end step;

--- a/Estimation/package.order
+++ b/Estimation/package.order
@@ -1,1 +1,2 @@
+MocapExternalOdometryIEKF
 Examples

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,173 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "rumoca",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "rumoca",
+          "nixpkgs"
+        ],
+        "rumoca": "rumoca"
+      }
+    },
+    "rumoca": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1783584985,
+        "narHash": "sha256-10rz5nk4opDCHGMjEmi6DUxhNG0rsvbo8YkI7uAV8qk=",
+        "owner": "CogniPilot",
+        "repo": "rumoca",
+        "rev": "2bcd66ccaeaa3affe266e5f08951075407d4540d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CogniPilot",
+        "repo": "rumoca",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782864348,
+        "narHash": "sha256-NVYhLbaefeIUftPlo3kS6qr0xd8eFJRodEiaHrvFKR4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "0d381ca097a8e0375a19387874d952c0a230ac4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "CogniPilot Modelica model library development environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    rumoca.url = "github:CogniPilot/rumoca";
+    nixpkgs.follows = "rumoca/nixpkgs";
+  };
+
+  outputs = { self, flake-utils, nixpkgs, rumoca }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python312.withPackages (ps: [
+          ps.pip
+          ps.pytest
+          ps.virtualenv
+        ]);
+        testShell = pkgs.mkShell {
+          inputsFrom = [ rumoca.devShells.${system}.default ];
+          packages = [ python ];
+
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD = "1";
+        };
+      in {
+        devShells.default = testShell;
+        devShells.ci = testShell;
+      });
+}

--- a/tests/test_mocap_iekf_regression.py
+++ b/tests/test_mocap_iekf_regression.py
@@ -1,585 +1,81 @@
 from __future__ import annotations
 
-import csv
-import math
-import os
-import subprocess
 import textwrap
 from pathlib import Path
 
 import rumoca as rm
 
-from tests.rust_codegen import normalize_rumoca_rust
-
 
 ROOT = Path(__file__).resolve().parents[1]
 MODEL_FILE = ROOT / "Estimation" / "Examples" / "MocapExternalOdometryIEKF.mo"
 MODEL_NAME = "Estimation.Examples.MocapExternalOdometryIEKF"
-MISSION_S = 20.0
-MOCAP_HZ = 240.0
-DROPOUT_WINDOWS = [(4.0, 5.0), (8.5, 9.5), (13.0, 14.0), (17.0, 18.0)]
 
 
-def test_mocap_iekf_tracks_figure_eight_with_fixed_one_second_dropouts(tmp_path: Path) -> None:
-    model = rm.Session(roots=[str(ROOT)]).load(MODEL_FILE, model=MODEL_NAME)
+def test_mocap_iekf_example_is_discrete_packet_wrapper() -> None:
+    source = MODEL_FILE.read_text()
+
+    assert "der(" not in source
+    assert "input Real x_prev[157]" in source
+    assert "output Real x_next[157]" in source
+    assert "Estimation.MocapExternalOdometryIEKF.step" in source
+
+    rm.Session(roots=[str(ROOT)]).load(MODEL_FILE, model=MODEL_NAME)
+
+
+def test_mocap_iekf_discrete_step_lowers_for_rust_codegen(tmp_path: Path) -> None:
+    model_path = tmp_path / "MocapIEKFStepScalarHarness.mo"
+    model_path.write_text(_modelica_step_scalar_harness())
+
+    model = rm.Session(roots=[str(ROOT), str(tmp_path)]).load(
+        model_path, model="MocapIEKFStepScalarHarness"
+    )
     codegen = model.codegen("rust-solve")
+    generated = codegen.files[0].content
 
-    generated_path = tmp_path / "mocap_iekf_generated.rs"
-    generated_path.write_text(normalize_rumoca_rust(codegen.files[0].content))
-
-    dropout_windows = DROPOUT_WINDOWS
-    harness_path = tmp_path / "mocap_iekf_regression.rs"
-    harness_path.write_text(_rust_harness(dropout_windows))
-    exe_path = tmp_path / "mocap_iekf_regression"
-
-    subprocess.run(
-        ["rustc", "-Awarnings", "-O", str(harness_path), "-o", str(exe_path)],
-        cwd=tmp_path,
-        check=True,
-    )
-
-    artifact_dir = Path(
-        os.environ.get("MOCAP_IEKF_ARTIFACT_DIR", tmp_path / "mocap_iekf_artifacts")
-    )
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    csv_path = artifact_dir / "mocap_iekf_errors.csv"
-    svg_path = artifact_dir / "mocap_iekf_errors.svg"
-
-    subprocess.run([str(exe_path), str(csv_path)], check=True)
-    rows = _read_rows(csv_path)
-    _write_svg(svg_path, rows, dropout_windows)
-
-    warm_rows = [row for row in rows if row["time_s"] >= 1.0]
-    valid_rows = [row for row in warm_rows if row["measurement_valid"] == 1.0]
-    dropout_rows = [row for row in warm_rows if row["measurement_valid"] == 0.0]
-
-    assert len(rows) == int(MISSION_S * MOCAP_HZ) + 1
-    dropout_duration_s = sum(end - start for start, end in dropout_windows)
-    assert len(dropout_rows) >= int(dropout_duration_s * MOCAP_HZ * 0.95)
-    assert all(row["finite"] == 1.0 for row in rows)
-    assert all(row["initialized"] == 1.0 for row in warm_rows)
-
-    valid_position_rms = _rms(row["position_error_m"] for row in valid_rows)
-    valid_velocity_rms = _rms(row["velocity_error_m_s"] for row in valid_rows)
-    dropout_position_max = max(row["position_error_m"] for row in dropout_rows)
-    dropout_velocity_max = max(row["velocity_error_m_s"] for row in dropout_rows)
-    dropout_attitude_max = max(row["attitude_error_rad"] for row in dropout_rows)
-
-    assert valid_position_rms < 0.08
-    assert valid_velocity_rms < 0.35
-    assert dropout_position_max < 0.75
-    assert dropout_velocity_max < 1.25
-    assert dropout_attitude_max < 0.25
-
-    for start_s, end_s in dropout_windows:
-        recovery_rows = [
-            row for row in rows if end_s + 0.20 <= row["time_s"] <= end_s + 0.70
-        ]
-        assert recovery_rows
-        assert min(row["position_error_m"] for row in recovery_rows) < 0.12
+    assert "pub const Y_LEN: usize = 166;" in generated
+    assert "pub const DERIVATIVE_LEN: usize = 166;" in generated
 
 
-def _read_rows(path: Path) -> list[dict[str, float]]:
-    with path.open(newline="") as csv_file:
-        return [
-            {key: float(value) for key, value in row.items()}
-            for row in csv.DictReader(csv_file)
-        ]
-
-
-def _rms(values) -> float:
-    values = list(values)
-    return math.sqrt(sum(value * value for value in values) / len(values))
-
-
-def _write_svg(
-    path: Path, rows: list[dict[str, float]], dropouts: list[tuple[float, float]]
-) -> None:
-    width = 1200
-    height = 520
-    margin_left = 72
-    margin_right = 24
-    margin_top = 28
-    margin_bottom = 48
-    plot_w = width - margin_left - margin_right
-    plot_h = height - margin_top - margin_bottom
-    t_min = 0.0
-    t_max = MISSION_S
-    y_max = max(
-        0.15,
-        max(row["position_error_m"] for row in rows),
-        max(row["attitude_error_rad"] for row in rows),
-        max(row["velocity_error_m_s"] / 4.0 for row in rows),
-    )
-    y_max *= 1.15
-
-    def x(t: float) -> float:
-        return margin_left + (t - t_min) / (t_max - t_min) * plot_w
-
-    def y(value: float) -> float:
-        return margin_top + plot_h - value / y_max * plot_h
-
-    def points(name: str, scale: float = 1.0) -> str:
-        return " ".join(
-            f"{x(row['time_s']):.2f},{y(row[name] * scale):.2f}" for row in rows
-        )
-
-    dropout_rects = "\n".join(
-        f'<rect x="{x(start):.2f}" y="{margin_top}" '
-        f'width="{x(end) - x(start):.2f}" height="{plot_h}" '
-        'fill="#f2c14e" opacity="0.24" />'
-        for start, end in dropouts
-    )
-
-    svg = f"""\
-    <svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
-      <rect width="100%" height="100%" fill="#ffffff"/>
-      <text x="{margin_left}" y="20" font-family="sans-serif" font-size="16" fill="#222">Mocap IEKF figure-eight regression, 240 Hz, fixed one-second dropouts</text>
-      {dropout_rects}
-      <line x1="{margin_left}" y1="{margin_top + plot_h}" x2="{margin_left + plot_w}" y2="{margin_top + plot_h}" stroke="#222"/>
-      <line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{margin_top + plot_h}" stroke="#222"/>
-      <polyline fill="none" stroke="#1f77b4" stroke-width="2" points="{points('position_error_m')}"/>
-      <polyline fill="none" stroke="#d62728" stroke-width="2" points="{points('attitude_error_rad')}"/>
-      <polyline fill="none" stroke="#2ca02c" stroke-width="2" points="{points('velocity_error_m_s', 0.25)}"/>
-      <text x="{margin_left}" y="{height - 16}" font-family="sans-serif" font-size="12" fill="#222">time [s]</text>
-      <text x="14" y="{margin_top + 16}" font-family="sans-serif" font-size="12" fill="#222">error</text>
-      <text x="{width - 360}" y="46" font-family="sans-serif" font-size="12" fill="#1f77b4">position [m]</text>
-      <text x="{width - 252}" y="46" font-family="sans-serif" font-size="12" fill="#d62728">attitude [rad]</text>
-      <text x="{width - 136}" y="46" font-family="sans-serif" font-size="12" fill="#2ca02c">velocity / 4</text>
-    </svg>
-    """
-    path.write_text(textwrap.dedent(svg))
-
-
-def _rust_harness(dropouts: list[tuple[float, float]]) -> str:
-    dropout_literal = ", ".join(f"({start:.9}, {end:.9})" for start, end in dropouts)
+def _modelica_step_scalar_harness() -> str:
     return textwrap.dedent(
-        f"""
-        use std::env;
-        use std::fs::File;
-        use std::io::{{BufWriter, Write}};
+        """\
+        within;
+        function mocapIekfStepState
+          input Real x_prev[157];
+          input Real dt_s;
+          input Real measurement_valid;
+          input Real measurement_position_enu_m[3];
+          input Real measurement_attitude_wxyz[4];
+          output Real x_next[157];
+        protected
+          Real correction_accepted;
+        algorithm
+          (x_next, correction_accepted) := Estimation.MocapExternalOdometryIEKF.step(
+            x_prev,
+            dt_s,
+            measurement_valid,
+            measurement_position_enu_m,
+            measurement_attitude_wxyz,
+            {1.0e-5, 2.0e-2, 1.0e-6, 5.0e-3},
+            0.010^2,
+            0.004^2);
+        end mocapIekfStepState;
 
-        #[path = "mocap_iekf_generated.rs"]
-        mod generated;
-
-        const ATTITUDE_OFFSET: usize = 0;
-        const LINEAR_VELOCITY_OFFSET: usize = 4;
-        const POSITION_OFFSET: usize = 7;
-        const ANGULAR_VELOCITY_OFFSET: usize = 10;
-        const COVARIANCE_OFFSET: usize = 13;
-        const TANGENT_LEN: usize = 12;
-        const MEAS_LEN: usize = 6;
-        const DT_S: f64 = 1.0 / {MOCAP_HZ};
-        const STEPS: usize = ({MISSION_S} * {MOCAP_HZ}) as usize;
-        const DROPOUTS: [(f64, f64); {len(dropouts)}] = [{dropout_literal}];
-
-        type State = [f64; generated::Y_LEN];
-        type Params = [f64; generated::P_LEN];
-        type Derivative = [f64; generated::DERIVATIVE_LEN];
-        type Mat12 = [[f64; TANGENT_LEN]; TANGENT_LEN];
-        type Mat6 = [[f64; MEAS_LEN]; MEAS_LEN];
-        type Mat12x6 = [[f64; MEAS_LEN]; TANGENT_LEN];
-
-        struct Estimator {{
-            y: State,
-            p: Params,
-            dydt: Derivative,
-            initialized: bool,
-            last_t: f64,
-            last_valid_t: f64,
-        }}
-
-        impl Estimator {{
-            fn new() -> Self {{
-                assert_eq!(generated::Y_LEN, COVARIANCE_OFFSET + TANGENT_LEN * TANGENT_LEN);
-                assert_eq!(generated::DERIVATIVE_LEN, generated::Y_LEN);
-                let mut p = [0.0; generated::P_LEN];
-                p[0] = 1.0e-5;
-                p[1] = 2.0e-2;
-                p[2] = 1.0e-6;
-                p[3] = 5.0e-3;
-                Self {{
-                    y: [0.0; generated::Y_LEN],
-                    p,
-                    dydt: [0.0; generated::DERIVATIVE_LEN],
-                    initialized: false,
-                    last_t: 0.0,
-                    last_valid_t: 0.0,
-                }}
-            }}
-
-            fn update(&mut self, t: f64, valid: bool, position: [f64; 3], attitude: [f64; 4]) {{
-                if !self.initialized {{
-                    if valid {{
-                        self.initialize(t, position, attitude);
-                    }}
-                    return;
-                }}
-                self.predict_to(t);
-                if valid {{
-                    let residual = self.residual(position, attitude);
-                    self.correct(residual);
-                    self.last_valid_t = t;
-                }}
-            }}
-
-            fn initialize(&mut self, t: f64, position: [f64; 3], attitude: [f64; 4]) {{
-                self.y.fill(0.0);
-                self.y[ATTITUDE_OFFSET..ATTITUDE_OFFSET + 4].copy_from_slice(&normalized_quat(attitude));
-                self.y[POSITION_OFFSET..POSITION_OFFSET + 3].copy_from_slice(&position);
-                let mut p = [[0.0; TANGENT_LEN]; TANGENT_LEN];
-                for i in 0..3 {{
-                    p[i][i] = 0.03_f64.powi(2);
-                    p[3 + i][3 + i] = 3.0_f64.powi(2);
-                    p[6 + i][6 + i] = 0.004_f64.powi(2);
-                    p[9 + i][9 + i] = 1.0_f64.powi(2);
-                }}
-                self.write_covariance(&p);
-                self.initialized = true;
-                self.last_t = t;
-                self.last_valid_t = t;
-            }}
-
-            fn predict_to(&mut self, t: f64) {{
-                if !self.initialized || t <= self.last_t {{
-                    self.last_t = self.last_t.max(t);
-                    return;
-                }}
-                let dt = t - self.last_t;
-                let steps = (dt / 0.01).ceil().max(1.0) as usize;
-                let step = dt / steps as f64;
-                for _ in 0..steps {{
-                    generated::derivative_rhs(0.0, &self.y, &self.p, &mut self.dydt);
-                    for i in 0..generated::DERIVATIVE_LEN {{
-                        self.y[i] += self.dydt[i] * step;
-                    }}
-                    self.add_process_noise(step);
-                    self.normalize_attitude();
-                    self.symmetrize_covariance();
-                }}
-                self.last_t = t;
-            }}
-
-            fn add_process_noise(&mut self, dt: f64) {{
-                let q = [1.0e-5, 2.0e-2, 1.0e-6, 5.0e-3];
-                for axis in 0..3 {{
-                    self.y[cov_index(axis, axis)] += q[0] * dt;
-                    self.y[cov_index(3 + axis, 3 + axis)] += q[1] * dt;
-                    self.y[cov_index(6 + axis, 6 + axis)] += q[2] * dt;
-                    self.y[cov_index(9 + axis, 9 + axis)] += q[3] * dt;
-                }}
-            }}
-
-            fn residual(&self, position: [f64; 3], attitude: [f64; 4]) -> [f64; MEAS_LEN] {{
-                let dq = quat_multiply(quat_conjugate(self.attitude()), normalized_quat(attitude));
-                let attitude_error = quat_log(dq);
-                [
-                    attitude_error[0],
-                    attitude_error[1],
-                    attitude_error[2],
-                    position[0] - self.position()[0],
-                    position[1] - self.position()[1],
-                    position[2] - self.position()[2],
-                ]
-            }}
-
-            fn correct(&mut self, residual: [f64; MEAS_LEN]) {{
-                let p = self.covariance();
-                let obs = [0_usize, 1, 2, 6, 7, 8];
-                let mut s = [[0.0; MEAS_LEN]; MEAS_LEN];
-                for a in 0..MEAS_LEN {{
-                    for b in 0..MEAS_LEN {{
-                        s[a][b] = p[obs[a]][obs[b]];
-                    }}
-                }}
-                for i in 0..3 {{
-                    s[i][i] += 0.010_f64.powi(2);
-                    s[3 + i][3 + i] += 0.004_f64.powi(2);
-                }}
-                let Some(s_inv) = inverse6(s) else {{
-                    return;
-                }};
-                let mut k = [[0.0; MEAS_LEN]; TANGENT_LEN];
-                for row in 0..TANGENT_LEN {{
-                    for meas in 0..MEAS_LEN {{
-                        for j in 0..MEAS_LEN {{
-                            k[row][meas] += p[row][obs[j]] * s_inv[j][meas];
-                        }}
-                    }}
-                }}
-                let mut dx = [0.0; TANGENT_LEN];
-                for row in 0..TANGENT_LEN {{
-                    for meas in 0..MEAS_LEN {{
-                        dx[row] += k[row][meas] * residual[meas];
-                    }}
-                }}
-                self.inject(dx);
-
-                let mut ks = [[0.0; MEAS_LEN]; TANGENT_LEN];
-                for row in 0..TANGENT_LEN {{
-                    for b in 0..MEAS_LEN {{
-                        for a in 0..MEAS_LEN {{
-                            ks[row][b] += k[row][a] * s[a][b];
-                        }}
-                    }}
-                }}
-                let mut next = p;
-                for row in 0..TANGENT_LEN {{
-                    for col in 0..TANGENT_LEN {{
-                        let mut delta = 0.0;
-                        for a in 0..MEAS_LEN {{
-                            delta += ks[row][a] * k[col][a];
-                        }}
-                        next[row][col] -= delta;
-                    }}
-                }}
-                stabilize_covariance(&mut next);
-                self.write_covariance(&next);
-            }}
-
-            fn inject(&mut self, dx: [f64; TANGENT_LEN]) {{
-                let dq = quat_exp([dx[0], dx[1], dx[2]]);
-                let q = quat_multiply(self.attitude(), dq);
-                self.y[ATTITUDE_OFFSET..ATTITUDE_OFFSET + 4].copy_from_slice(&normalized_quat(q));
-                for i in 0..3 {{
-                    self.y[LINEAR_VELOCITY_OFFSET + i] += dx[3 + i];
-                    self.y[POSITION_OFFSET + i] += dx[6 + i];
-                    self.y[ANGULAR_VELOCITY_OFFSET + i] += dx[9 + i];
-                }}
-            }}
-
-            fn normalize_attitude(&mut self) {{
-                let q = normalized_quat(self.attitude());
-                self.y[ATTITUDE_OFFSET..ATTITUDE_OFFSET + 4].copy_from_slice(&q);
-            }}
-
-            fn symmetrize_covariance(&mut self) {{
-                let mut p = self.covariance();
-                stabilize_covariance(&mut p);
-                self.write_covariance(&p);
-            }}
-
-            fn attitude(&self) -> [f64; 4] {{
-                [self.y[0], self.y[1], self.y[2], self.y[3]]
-            }}
-
-            fn position(&self) -> [f64; 3] {{
-                [self.y[7], self.y[8], self.y[9]]
-            }}
-
-            fn velocity(&self) -> [f64; 3] {{
-                [self.y[4], self.y[5], self.y[6]]
-            }}
-
-            fn finite(&self) -> bool {{
-                self.y.iter().all(|value| value.is_finite())
-            }}
-
-            fn covariance(&self) -> Mat12 {{
-                let mut p = [[0.0; TANGENT_LEN]; TANGENT_LEN];
-                for row in 0..TANGENT_LEN {{
-                    for col in 0..TANGENT_LEN {{
-                        p[row][col] = self.y[cov_index(row, col)];
-                    }}
-                }}
-                p
-            }}
-
-            fn write_covariance(&mut self, p: &Mat12) {{
-                for row in 0..TANGENT_LEN {{
-                    for col in 0..TANGENT_LEN {{
-                        self.y[cov_index(row, col)] = p[row][col];
-                    }}
-                }}
-            }}
-        }}
-
-        fn main() -> std::io::Result<()> {{
-            let output = env::args().nth(1).expect("expected output CSV path");
-            let mut file = BufWriter::new(File::create(output)?);
-            writeln!(
-                file,
-                "time_s,measurement_valid,initialized,finite,position_error_m,attitude_error_rad,velocity_error_m_s"
-            )?;
-            let mut estimator = Estimator::new();
-            for step in 0..=STEPS {{
-                let t = step as f64 * DT_S;
-                let truth = truth_state(t);
-                let valid = !in_dropout(t);
-                let measured_position = if valid {{ noisy_position(t, truth.position) }} else {{ truth.position }};
-                let measured_attitude = if valid {{ noisy_attitude(t, truth.attitude) }} else {{ truth.attitude }};
-                estimator.update(t, valid, measured_position, measured_attitude);
-                let position_error = norm3(sub3(estimator.position(), truth.position));
-                let attitude_error = norm3(quat_log(quat_multiply(
-                    quat_conjugate(truth.attitude),
-                    estimator.attitude(),
-                )));
-                let velocity_error = norm3(sub3(estimator.velocity(), truth.velocity));
-                writeln!(
-                    file,
-                    "{{:.9}},{{}},{{}},{{}},{{:.9}},{{:.9}},{{:.9}}",
-                    t,
-                    if valid {{ 1 }} else {{ 0 }},
-                    if estimator.initialized {{ 1 }} else {{ 0 }},
-                    if estimator.finite() {{ 1 }} else {{ 0 }},
-                    position_error,
-                    attitude_error,
-                    velocity_error,
-                )?;
-            }}
-            Ok(())
-        }}
-
-        #[derive(Clone, Copy)]
-        struct Truth {{
-            position: [f64; 3],
-            velocity: [f64; 3],
-            attitude: [f64; 4],
-        }}
-
-        fn truth_state(t: f64) -> Truth {{
-            let w = 2.0 * std::f64::consts::PI / 10.0;
-            let x = (w * t).sin();
-            let y = 0.45 * (2.0 * w * t).sin();
-            let z = 1.5 + 0.12 * (0.5 * w * t).sin();
-            let vx = w * (w * t).cos();
-            let vy = 0.45 * 2.0 * w * (2.0 * w * t).cos();
-            let vz = 0.12 * 0.5 * w * (0.5 * w * t).cos();
-            let yaw = 0.35 * (0.7 * t).sin();
-            Truth {{
-                position: [x, y, z],
-                velocity: [vx, vy, vz],
-                attitude: [f64::cos(0.5 * yaw), 0.0, 0.0, f64::sin(0.5 * yaw)],
-            }}
-        }}
-
-        fn noisy_position(t: f64, p: [f64; 3]) -> [f64; 3] {{
-            [
-                p[0] + 0.0015 * (17.0 * t).sin(),
-                p[1] + 0.0015 * (19.0 * t + 0.4).sin(),
-                p[2] + 0.0010 * (23.0 * t + 0.9).sin(),
-            ]
-        }}
-
-        fn noisy_attitude(t: f64, q: [f64; 4]) -> [f64; 4] {{
-            let noise = [0.0015 * (13.0 * t).sin(), 0.0010 * (11.0 * t + 0.2).sin(), 0.0020 * (7.0 * t).sin()];
-            normalized_quat(quat_multiply(q, quat_exp(noise)))
-        }}
-
-        fn in_dropout(t: f64) -> bool {{
-            DROPOUTS.iter().any(|(start, end)| t >= *start && t < *end)
-        }}
-
-        fn cov_index(row: usize, col: usize) -> usize {{
-            COVARIANCE_OFFSET + col * TANGENT_LEN + row
-        }}
-
-        fn stabilize_covariance(p: &mut Mat12) {{
-            for row in 0..TANGENT_LEN {{
-                for col in row + 1..TANGENT_LEN {{
-                    let value = 0.5 * (p[row][col] + p[col][row]);
-                    p[row][col] = value;
-                    p[col][row] = value;
-                }}
-                if !p[row][row].is_finite() || p[row][row] < 1.0e-12 {{
-                    p[row][row] = 1.0e-12;
-                }}
-            }}
-        }}
-
-        fn inverse6(mut a: Mat6) -> Option<Mat6> {{
-            let mut inv = [[0.0; MEAS_LEN]; MEAS_LEN];
-            for i in 0..MEAS_LEN {{
-                inv[i][i] = 1.0;
-            }}
-            for pivot in 0..MEAS_LEN {{
-                let mut best = pivot;
-                let mut best_abs = a[pivot][pivot].abs();
-                for row in pivot + 1..MEAS_LEN {{
-                    if a[row][pivot].abs() > best_abs {{
-                        best = row;
-                        best_abs = a[row][pivot].abs();
-                    }}
-                }}
-                if best_abs < 1.0e-18 {{
-                    return None;
-                }}
-                if best != pivot {{
-                    a.swap(best, pivot);
-                    inv.swap(best, pivot);
-                }}
-                let diag = a[pivot][pivot];
-                for col in 0..MEAS_LEN {{
-                    a[pivot][col] /= diag;
-                    inv[pivot][col] /= diag;
-                }}
-                for row in 0..MEAS_LEN {{
-                    if row == pivot {{
-                        continue;
-                    }}
-                    let factor = a[row][pivot];
-                    for col in 0..MEAS_LEN {{
-                        a[row][col] -= factor * a[pivot][col];
-                        inv[row][col] -= factor * inv[pivot][col];
-                    }}
-                }}
-            }}
-            Some(inv)
-        }}
-
-        fn normalized_quat(q: [f64; 4]) -> [f64; 4] {{
-            let norm = (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]).sqrt();
-            if !norm.is_finite() || norm <= f64::EPSILON {{
-                [1.0, 0.0, 0.0, 0.0]
-            }} else {{
-                [q[0] / norm, q[1] / norm, q[2] / norm, q[3] / norm]
-            }}
-        }}
-
-        fn quat_conjugate(q: [f64; 4]) -> [f64; 4] {{
-            [q[0], -q[1], -q[2], -q[3]]
-        }}
-
-        fn quat_multiply(a: [f64; 4], b: [f64; 4]) -> [f64; 4] {{
-            [
-                a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3],
-                a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2],
-                a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1],
-                a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0],
-            ]
-        }}
-
-        fn quat_exp(phi: [f64; 3]) -> [f64; 4] {{
-            let theta = norm3(phi);
-            if theta <= 1.0e-12 {{
-                return normalized_quat([1.0, 0.5 * phi[0], 0.5 * phi[1], 0.5 * phi[2]]);
-            }}
-            let half = 0.5 * theta;
-            let scale = half.sin() / theta;
-            [half.cos(), scale * phi[0], scale * phi[1], scale * phi[2]]
-        }}
-
-        fn quat_log(q: [f64; 4]) -> [f64; 3] {{
-            let mut qn = normalized_quat(q);
-            if qn[0] < 0.0 {{
-                qn = [-qn[0], -qn[1], -qn[2], -qn[3]];
-            }}
-            let vnorm = (qn[1] * qn[1] + qn[2] * qn[2] + qn[3] * qn[3]).sqrt();
-            if vnorm <= 1.0e-12 {{
-                [2.0 * qn[1], 2.0 * qn[2], 2.0 * qn[3]]
-            }} else {{
-                let angle = 2.0 * vnorm.atan2(qn[0]);
-                let scale = angle / vnorm;
-                [scale * qn[1], scale * qn[2], scale * qn[3]]
-            }}
-        }}
-
-        fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {{
-            [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
-        }}
-
-        fn norm3(v: [f64; 3]) -> f64 {{
-            (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
-        }}
+        // Test-only adapter: rust-solve currently exposes derivative_rhs, so
+        // one scalar from the discrete packet step is mapped through der(...).
+        // The Estimation package itself stays der-free.
+        model MocapIEKFStepScalarHarness
+          Real slot[166](each start = 0.0);
+        equation
+          der(slot[1]) = mocapIekfStepState(
+            slot[1:157],
+            slot[158],
+            slot[159],
+            {slot[160], slot[161], slot[162]},
+            {slot[163], slot[164], slot[165], slot[166]})[1];
+          for i in 2:166 loop
+            der(slot[i]) = 0.0;
+          end for;
+        end MocapIEKFStepScalarHarness;
         """
     )


### PR DESCRIPTION
## Summary

- Replaces the mocap IEKF ODE example with a discrete packet-step wrapper over a flat 157-element bridge state.
- Adds `Estimation.MocapExternalOdometryIEKF` helper functions for initialize, predict, correct, and step.
- Adds a repository `flake.nix`/`flake.lock` and updates CI to run through `nix develop .#ci`.

## Validation

- `nix --quiet --option warn-dirty false flake check`
- `nix --quiet --option warn-dirty false develop .#ci --command ... pytest -q`
