### PR TITLE
Add fixed-gain position estimator

### DIFF
--- a/Estimation/PositionEstimator.mo
+++ b/Estimation/PositionEstimator.mo
@@ -1,0 +1,117 @@
+within Estimation;
+model PositionEstimator
+  "Fixed-gain GPS/mocap position estimator with inertial propagation"
+  parameter Real samplePeriod(unit="s") = 0.005;
+  parameter Real gravity_m_s2(unit="m/s2") = 9.81;
+  parameter Real initialPosition_m[3] = {0.0, 0.0, 0.0};
+  parameter Real initialVelocity_m_s[3] = {0.0, 0.0, 0.0};
+  parameter Real steadyStateGain[6, 3] = [
+    0.05, 0.0, 0.0;
+    0.0, 0.05, 0.0;
+    0.0, 0.0, 0.05;
+    0.03, 0.0, 0.0;
+    0.0, 0.03, 0.0;
+    0.0, 0.0, 0.03]
+    "Fixed gain; upper rows correct position and lower rows correct velocity";
+
+  input Real attitude_wb[4](start={1.0, 0.0, 0.0, 0.0})
+    "Estimated scalar-first quaternion from body FLU to world ENU";
+  input Real specificForce_b_m_s2[3](start={0.0, 0.0, gravity_m_s2})
+    "Raw accelerometer specific force in body FLU [m/s2]";
+  input Real measuredPosition_m[3](each start=0.0)
+    "Local Cartesian GPS or mocap position in world ENU [m]";
+  input Boolean measurementFresh(start=false)
+    "True for exactly one estimator tick when a new valid measurement arrives";
+  input Boolean reset(start=true);
+
+  discrete output Real position_m[3](each start=0.0)
+    "Estimated position in world ENU [m]";
+  discrete output Real velocity_m_s[3](each start=0.0)
+    "Estimated velocity in world ENU [m/s]";
+  discrete output Real acceleration_m_s2[3](each start=0.0)
+    "Estimated inertial acceleration in world ENU [m/s2]";
+  discrete output Real positionResidual_m[3](each start=0.0)
+    "Latest accepted position innovation [m]";
+  discrete output Boolean correctionApplied(start=false);
+
+protected
+  discrete Real predictedPosition_m[3](each start=0.0);
+  discrete Real predictedVelocity_m_s[3](each start=0.0);
+  discrete Real stateCorrection[6](each start=0.0);
+  discrete Real attitudeNorm(start=1.0);
+  discrete Real normalizedAttitude[4](start={1.0, 0.0, 0.0, 0.0});
+
+algorithm
+  when sample(0.0, samplePeriod) then
+    attitudeNorm := max(sqrt(
+      attitude_wb[1] * attitude_wb[1]
+        + attitude_wb[2] * attitude_wb[2]
+        + attitude_wb[3] * attitude_wb[3]
+        + attitude_wb[4] * attitude_wb[4]), 1.0e-10);
+    normalizedAttitude := attitude_wb / attitudeNorm;
+    acceleration_m_s2[1] :=
+      (1.0 - 2.0 * (normalizedAttitude[3] * normalizedAttitude[3]
+        + normalizedAttitude[4] * normalizedAttitude[4]))
+        * specificForce_b_m_s2[1]
+      + 2.0 * (normalizedAttitude[2] * normalizedAttitude[3]
+        - normalizedAttitude[1] * normalizedAttitude[4])
+        * specificForce_b_m_s2[2]
+      + 2.0 * (normalizedAttitude[2] * normalizedAttitude[4]
+        + normalizedAttitude[1] * normalizedAttitude[3])
+        * specificForce_b_m_s2[3];
+    acceleration_m_s2[2] :=
+      2.0 * (normalizedAttitude[2] * normalizedAttitude[3]
+        + normalizedAttitude[1] * normalizedAttitude[4])
+        * specificForce_b_m_s2[1]
+      + (1.0 - 2.0 * (normalizedAttitude[2] * normalizedAttitude[2]
+        + normalizedAttitude[4] * normalizedAttitude[4]))
+        * specificForce_b_m_s2[2]
+      + 2.0 * (normalizedAttitude[3] * normalizedAttitude[4]
+        - normalizedAttitude[1] * normalizedAttitude[2])
+        * specificForce_b_m_s2[3];
+    acceleration_m_s2[3] :=
+      2.0 * (normalizedAttitude[2] * normalizedAttitude[4]
+        - normalizedAttitude[1] * normalizedAttitude[3])
+        * specificForce_b_m_s2[1]
+      + 2.0 * (normalizedAttitude[3] * normalizedAttitude[4]
+        + normalizedAttitude[1] * normalizedAttitude[2])
+        * specificForce_b_m_s2[2]
+      + (1.0 - 2.0 * (normalizedAttitude[2] * normalizedAttitude[2]
+        + normalizedAttitude[3] * normalizedAttitude[3]))
+        * specificForce_b_m_s2[3]
+      - gravity_m_s2;
+    predictedPosition_m := if reset then
+      (if measurementFresh then measuredPosition_m else initialPosition_m)
+      else pre(position_m) + pre(velocity_m_s) * samplePeriod
+        + 0.5 * acceleration_m_s2 * samplePeriod * samplePeriod;
+    predictedVelocity_m_s := if reset then initialVelocity_m_s
+      else pre(velocity_m_s) + acceleration_m_s2 * samplePeriod;
+    positionResidual_m := if not reset and measurementFresh then
+      measuredPosition_m - predictedPosition_m else {0.0, 0.0, 0.0};
+    stateCorrection[1] := steadyStateGain[1, 1] * positionResidual_m[1]
+      + steadyStateGain[1, 2] * positionResidual_m[2]
+      + steadyStateGain[1, 3] * positionResidual_m[3];
+    stateCorrection[2] := steadyStateGain[2, 1] * positionResidual_m[1]
+      + steadyStateGain[2, 2] * positionResidual_m[2]
+      + steadyStateGain[2, 3] * positionResidual_m[3];
+    stateCorrection[3] := steadyStateGain[3, 1] * positionResidual_m[1]
+      + steadyStateGain[3, 2] * positionResidual_m[2]
+      + steadyStateGain[3, 3] * positionResidual_m[3];
+    stateCorrection[4] := steadyStateGain[4, 1] * positionResidual_m[1]
+      + steadyStateGain[4, 2] * positionResidual_m[2]
+      + steadyStateGain[4, 3] * positionResidual_m[3];
+    stateCorrection[5] := steadyStateGain[5, 1] * positionResidual_m[1]
+      + steadyStateGain[5, 2] * positionResidual_m[2]
+      + steadyStateGain[5, 3] * positionResidual_m[3];
+    stateCorrection[6] := steadyStateGain[6, 1] * positionResidual_m[1]
+      + steadyStateGain[6, 2] * positionResidual_m[2]
+      + steadyStateGain[6, 3] * positionResidual_m[3];
+    position_m[1] := predictedPosition_m[1] + stateCorrection[1];
+    position_m[2] := predictedPosition_m[2] + stateCorrection[2];
+    position_m[3] := predictedPosition_m[3] + stateCorrection[3];
+    velocity_m_s[1] := predictedVelocity_m_s[1] + stateCorrection[4];
+    velocity_m_s[2] := predictedVelocity_m_s[2] + stateCorrection[5];
+    velocity_m_s[3] := predictedVelocity_m_s[3] + stateCorrection[6];
+    correctionApplied := measurementFresh;
+  end when;
+end PositionEstimator;

--- a/Estimation/PositionVelocityKF/State.mo
+++ b/Estimation/PositionVelocityKF/State.mo
@@ -1,0 +1,5 @@
+within Estimation.PositionVelocityKF;
+record State "World-frame translational estimator state"
+  Real position[3] "Position in world ENU coordinates [m]";
+  Real velocity[3] "Velocity in world ENU coordinates [m/s]";
+end State;

--- a/Estimation/PositionVelocityKF/bodySpecificForceToWorld.mo
+++ b/Estimation/PositionVelocityKF/bodySpecificForceToWorld.mo
@@ -1,0 +1,18 @@
+within Estimation.PositionVelocityKF;
+function bodySpecificForceToWorld
+  "Rotate IMU specific force to world ENU and add gravity"
+  input Real attitude_wb[4]
+    "Scalar-first quaternion rotating body FLU vectors to world ENU";
+  input Real specificForce_b_m_s2[3]
+    "Accelerometer specific force in body FLU coordinates [m/s2]";
+  input Real gravity_m_s2 = 9.81 "Positive gravitational acceleration";
+  output Real acceleration_w_m_s2[3]
+    "Gravity-compensated inertial acceleration in world ENU [m/s2]";
+protected
+  Real normalizedAttitude[4];
+algorithm
+  normalizedAttitude := LieGroups.SO3.Quat.normalize(attitude_wb);
+  acceleration_w_m_s2 := LieGroups.SO3.Quat.rotate(
+    normalizedAttitude,
+    specificForce_b_m_s2) + {0.0, 0.0, -gravity_m_s2};
+end bodySpecificForceToWorld;

--- a/Estimation/PositionVelocityKF/correct.mo
+++ b/Estimation/PositionVelocityKF/correct.mo
@@ -1,0 +1,16 @@
+within Estimation.PositionVelocityKF;
+function correct "Apply a fixed steady-state gain to a position measurement"
+  input Estimation.PositionVelocityKF.State predicted;
+  input Real measuredPosition[3]
+    "GPS- or mocap-derived position in world ENU coordinates [m]";
+  input Estimation.PositionVelocityKF.Gain gain;
+  output Estimation.PositionVelocityKF.State corrected;
+  output Real residual[3] "Measured minus predicted position [m]";
+protected
+  Real correction[6];
+algorithm
+  residual := measuredPosition - predicted.position;
+  correction := gain * residual;
+  corrected.position := predicted.position + correction[1:3];
+  corrected.velocity := predicted.velocity + correction[4:6];
+end correct;

--- a/Estimation/PositionVelocityKF/initialize.mo
+++ b/Estimation/PositionVelocityKF/initialize.mo
@@ -1,0 +1,10 @@
+within Estimation.PositionVelocityKF;
+function initialize "Initialize translational state"
+  input Real position[3] "Initial position in world ENU coordinates [m]";
+  input Real velocity[3] = zeros(3)
+    "Initial velocity in world ENU coordinates [m/s]";
+  output Estimation.PositionVelocityKF.State state;
+algorithm
+  state.position := position;
+  state.velocity := velocity;
+end initialize;

--- a/Estimation/PositionVelocityKF/package.mo
+++ b/Estimation/PositionVelocityKF/package.mo
@@ -1,0 +1,14 @@
+within Estimation;
+package PositionVelocityKF
+  "Fixed-gain position/velocity Kalman filter with external attitude"
+  constant Integer StateLength = 6
+    "State dimension for {world position, world velocity}";
+  constant Integer MeasurementLength = 3
+    "Cartesian position measurement dimension";
+
+  type Vector3 = Real[3] "Three-dimensional coordinate vector";
+  type Quaternion = Real[4]
+    "Scalar-first Hamilton quaternion {w,x,y,z}";
+  type Gain = Real[6, 3]
+    "Steady-state gain mapping position residual to state correction";
+end PositionVelocityKF;

--- a/Estimation/PositionVelocityKF/package.order
+++ b/Estimation/PositionVelocityKF/package.order
@@ -1,0 +1,11 @@
+StateLength
+MeasurementLength
+Vector3
+Quaternion
+Gain
+State
+initialize
+bodySpecificForceToWorld
+predict
+correct
+step

--- a/Estimation/PositionVelocityKF/predict.mo
+++ b/Estimation/PositionVelocityKF/predict.mo
@@ -1,0 +1,12 @@
+within Estimation.PositionVelocityKF;
+function predict "Constant-acceleration translational prediction"
+  input Estimation.PositionVelocityKF.State previous;
+  input Real acceleration_w_m_s2[3]
+    "Inertial acceleration in world ENU coordinates [m/s2]";
+  input Real dt "Prediction interval [s]";
+  output Estimation.PositionVelocityKF.State predicted;
+algorithm
+  predicted.position := previous.position + previous.velocity * dt
+    + 0.5 * acceleration_w_m_s2 * dt * dt;
+  predicted.velocity := previous.velocity + acceleration_w_m_s2 * dt;
+end predict;

--- a/Estimation/PositionVelocityKF/step.mo
+++ b/Estimation/PositionVelocityKF/step.mo
@@ -1,0 +1,44 @@
+within Estimation.PositionVelocityKF;
+function step
+  "One IMU prediction and optional fresh Cartesian-position correction"
+  input Estimation.PositionVelocityKF.State previous;
+  input Real dt "Prediction interval [s]";
+  input Real attitude_wb[4]
+    "Scalar-first quaternion rotating body FLU vectors to world ENU";
+  input Real specificForce_b_m_s2[3]
+    "Accelerometer specific force in body FLU coordinates [m/s2]";
+  input Boolean measurementFresh
+    "True only on a tick containing a new valid position measurement";
+  input Real measuredPosition[3]
+    "GPS- or mocap-derived position in world ENU coordinates [m]";
+  input Estimation.PositionVelocityKF.Gain gain;
+  input Real gravity_m_s2 = 9.81 "Positive gravitational acceleration";
+  output Estimation.PositionVelocityKF.State next;
+  output Real acceleration_w_m_s2[3]
+    "Gravity-compensated inertial acceleration in world ENU [m/s2]";
+  output Real residual[3] "Position innovation, or zero without correction [m]";
+  output Boolean correctionApplied;
+protected
+  Estimation.PositionVelocityKF.State predicted;
+algorithm
+  acceleration_w_m_s2 :=
+    Estimation.PositionVelocityKF.bodySpecificForceToWorld(
+      attitude_wb,
+      specificForce_b_m_s2,
+      gravity_m_s2);
+  predicted := Estimation.PositionVelocityKF.predict(
+    previous,
+    acceleration_w_m_s2,
+    dt);
+  if measurementFresh then
+    (next, residual) := Estimation.PositionVelocityKF.correct(
+      predicted,
+      measuredPosition,
+      gain);
+    correctionApplied := true;
+  else
+    next := predicted;
+    residual := zeros(3);
+    correctionApplied := false;
+  end if;
+end step;

--- a/Estimation/package.order
+++ b/Estimation/package.order
@@ -1,2 +1,4 @@
 ComplementaryAttitude
+PositionEstimator
+PositionVelocityKF
 MocapExternalOdometryIEKF

--- a/Tests/EstimationTests.mo
+++ b/Tests/EstimationTests.mo
@@ -26,10 +26,21 @@ model EstimationTests "Initialization, prediction, correction, and failure invar
     Estimation.MocapExternalOdometryIEKF.Covariance discreteNoise;
     Estimation.MocapExternalOdometryIEKF.MeasurementMatrix measurementMatrix;
     Real expectedAttitudeTransition[3, 3];
+    Estimation.PositionVelocityKF.State positionInitialized;
+    Estimation.PositionVelocityKF.State positionPrevious;
+    Estimation.PositionVelocityKF.State positionPredicted;
+    Estimation.PositionVelocityKF.State positionCorrected;
+    Estimation.PositionVelocityKF.State positionStepped;
+    Estimation.PositionVelocityKF.Gain positionGain;
+    Real restAcceleration[3];
+    Real positionResidual[3];
+    Real stepAcceleration[3];
+    Real stepResidual[3];
     Boolean accepted;
     Boolean signAccepted;
     Boolean rejected;
     Boolean skippedAccepted;
+    Boolean positionCorrectionApplied;
   algorithm
   initialVariances := Estimation.MocapExternalOdometryIEKF.InitialVariances(
     attitude=0.04,
@@ -123,6 +134,40 @@ model EstimationTests "Initialization, prediction, correction, and failure invar
       angularVelocity=moving.angularVelocity),
     {0.0, 0.0, 0.1, 1.0, 2.0, 3.0, -1.0, -2.0, -3.0, 0.4, 0.5, 0.6});
 
+  positionInitialized := Estimation.PositionVelocityKF.initialize(
+    {1.0, -2.0, 0.5},
+    {2.0, 0.0, -1.0});
+  restAcceleration :=
+    Estimation.PositionVelocityKF.bodySpecificForceToWorld(
+      {1.0, 0.0, 0.0, 0.0},
+      {0.0, 0.0, 9.81},
+      9.81);
+  positionPrevious := positionInitialized;
+  positionPredicted := Estimation.PositionVelocityKF.predict(
+    positionPrevious,
+    {4.0, -2.0, 1.0},
+    0.25);
+  positionGain := zeros(6, 3);
+  for axis in 1:3 loop
+    positionGain[axis, axis] := 0.5;
+    positionGain[axis + 3, axis] := 0.25;
+  end for;
+  (positionCorrected, positionResidual) :=
+    Estimation.PositionVelocityKF.correct(
+      positionPredicted,
+      positionPredicted.position + {2.0, -4.0, 1.0},
+      positionGain);
+  (positionStepped, stepAcceleration, stepResidual,
+    positionCorrectionApplied) := Estimation.PositionVelocityKF.step(
+      positionPrevious,
+      0.1,
+      {1.0, 0.0, 0.0, 0.0},
+      {0.0, 0.0, 9.81},
+      false,
+      zeros(3),
+      positionGain,
+      9.81);
+
   assert(Tests.Assertions.maxAbsVector(initialized.attitude - {1, 0, 0, 0}) < tolerance,
     "IEKF initialization did not normalize attitude");
   assert(Tests.Assertions.maxAbsVector(initialized.velocity) < tolerance,
@@ -176,6 +221,31 @@ model EstimationTests "Initialization, prediction, correction, and failure invar
          Tests.Assertions.maxAbsVector(injected.position - (moving.position - {1, 2, 3})) < tolerance and
          Tests.Assertions.maxAbsVector(injected.angularVelocity - (moving.angularVelocity + {0.4, 0.5, 0.6})) < tolerance,
     "IEKF tangent injection ordering failed");
+  assert(Tests.Assertions.maxAbsVector(
+      restAcceleration) < tolerance,
+    "Position filter did not remove gravity from a stationary IMU");
+  assert(Tests.Assertions.maxAbsVector(
+      positionPredicted.position - {1.625, -2.0625, 0.28125}) < tolerance and
+      Tests.Assertions.maxAbsVector(
+        positionPredicted.velocity - {3.0, -0.5, -0.75}) < tolerance,
+    "Position filter constant-acceleration prediction failed");
+  assert(Tests.Assertions.maxAbsVector(
+      positionResidual - {2.0, -4.0, 1.0}) < tolerance and
+      Tests.Assertions.maxAbsVector(
+        positionCorrected.position -
+          (positionPredicted.position + {1.0, -2.0, 0.5})) < tolerance and
+      Tests.Assertions.maxAbsVector(
+        positionCorrected.velocity -
+          (positionPredicted.velocity + {0.5, -1.0, 0.25})) < tolerance,
+    "Position filter fixed-gain correction failed");
+  assert(not positionCorrectionApplied and
+      Tests.Assertions.maxAbsVector(stepAcceleration) < tolerance and
+      Tests.Assertions.maxAbsVector(stepResidual) < tolerance and
+      Tests.Assertions.maxAbsVector(
+        positionStepped.position - {1.2, -2.0, 0.4}) < tolerance and
+      Tests.Assertions.maxAbsVector(
+        positionStepped.velocity - positionPrevious.velocity) < tolerance,
+    "Position filter prediction-only step failed");
   for i in 1:12 loop
     assert(corrected.covariance[i, i] >= -tolerance,
       "IEKF corrected covariance had a negative diagonal");


### PR DESCRIPTION
## Summary

- add a sampled fixed-gain Cartesian position/velocity estimator
- add reusable initialization, inertial-frame conversion, prediction, correction, and step functions under `Estimation.PositionVelocityKF`
- add Modelica assertions for gravity removal, constant-acceleration prediction, fixed-gain correction, and prediction-only operation

## Validation

- `checkModel(Tests.All)` passes with 2,922 equations and variables
- direct Rumoca `galec-production` compilation of `Estimation.PositionEstimator` passes and produces a schema-valid eFMU with generated C99 and round-trip-valid GALEC
- the full current-main OpenModelica simulation proceeds through initialization, then stops in the untouched `Tests/DynamicsTests/PrincipalAxisTorque.mo` quaternion-norm assertion at `t=1.0`
- the full current-main Rumoca suite stops in the untouched CUBS2 estimator because its if-equation branches have mismatched equation counts

The obsolete RDD2 `Qualification` files from the older West-pinned checkout are intentionally not restored; this PR is rebased onto the current vehicle-test structure on `main`.
